### PR TITLE
mpv-renderer: add video source plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 /build*
 .cache
 /bin
+/install/

--- a/BUILD.md
+++ b/BUILD.md
@@ -32,5 +32,6 @@ cmake --install build/clang-release
 ```bash
 cd ./install
 export QML_IMPORT_PATH=./lib/qt6/qml
+export LD_LIBRARY_PATH="$PWD/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ../target/release/waywallen --ui ./bin/waywallen-ui --plugin ./share/waywallen
 ```

--- a/plugins/mpv/CMakeLists.txt
+++ b/plugins/mpv/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(waywallen-mpv-renderer
 # Install: matches the layout the waywallen daemon scans via --plugin.
 #   <prefix>/bin/waywallen-mpv-renderer
 #   <prefix>/share/waywallen/renderers/waywallen-mpv.toml
+#   <prefix>/share/waywallen/sources/video.lua
 # ---------------------------------------------------------------------------
 
 include(GNUInstallDirs)
@@ -77,4 +78,9 @@ install(TARGETS waywallen-mpv-renderer
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/renderers/
     DESTINATION ${CMAKE_INSTALL_DATADIR}/waywallen/renderers
     FILES_MATCHING PATTERN "*.toml"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/sources/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/waywallen/sources
+    FILES_MATCHING PATTERN "*.lua"
 )

--- a/plugins/mpv/sources/video.lua
+++ b/plugins/mpv/sources/video.lua
@@ -1,0 +1,114 @@
+-- video - waywallen source plugin for local video wallpapers.
+--
+-- Installed to <prefix>/share/waywallen/sources/video.lua. Emits entries
+-- with wp_type = "video" that the daemon routes to waywallen-mpv-renderer.
+-- Metadata `video` / `path` both carry the absolute file path; the daemon
+-- forwards them as `--video <path>` and `--path <path>`.
+
+local M = {}
+
+function M.info()
+    return {
+        name = "video",
+        types = {"video"},
+        version = "0.1.0",
+    }
+end
+
+local VIDEO_EXTS = {
+    mp4 = true, m4v = true, mkv = true, webm = true,
+    mov = true, avi = true, flv = true, wmv = true,
+    mpg = true, mpeg = true, ts = true, m2ts = true,
+    ogv = true, ogm = true,
+}
+
+local function strip_ext(name)
+    return name:match("(.+)%.[^.]+$") or name
+end
+
+local function first_existing(ctx, candidates)
+    local out, seen = {}, {}
+    for _, p in ipairs(candidates) do
+        if p and p ~= "" and not seen[p] and ctx.file_exists(p) then
+            seen[p] = true
+            table.insert(out, p)
+        end
+    end
+    return out
+end
+
+function M.auto_detect(ctx)
+    -- Probe XDG/home defaults; return paths that actually exist so
+    -- the daemon can register them as libraries.
+    local home = ctx.env("HOME")
+    local videos = ctx.env("XDG_VIDEOS_DIR")
+    local pictures = ctx.env("XDG_PICTURES_DIR")
+
+    local candidates = {}
+    if videos and videos ~= "" then table.insert(candidates, videos) end
+    if home and home ~= "" then table.insert(candidates, home .. "/Videos/Wallpapers") end
+    if home and home ~= "" then table.insert(candidates, home .. "/Videos") end
+    if pictures and pictures ~= "" then table.insert(candidates, pictures .. "/Wallpapers") end
+    if home and home ~= "" then table.insert(candidates, home .. "/Pictures/Wallpapers") end
+    return first_existing(ctx, candidates)
+end
+
+function M.scan(ctx)
+    local entries = {}
+    local dirs = {}
+    for _, d in ipairs(ctx.libraries()) do
+        if ctx.file_exists(d) then table.insert(dirs, d) end
+    end
+    if #dirs == 0 then
+        ctx.log("video: no video libraries configured")
+        return entries
+    end
+
+    local seen_path = {}
+    for _, dir in ipairs(dirs) do
+        -- The daemon's glob is the Rust `glob` crate, which does not expand
+        -- braces. Enumerate a few depth levels explicitly — enough for the
+        -- common "~/Videos/<album>/<file>" layouts without walking huge
+        -- trees on every scan.
+        local patterns = {
+            dir .. "/*.*",
+            dir .. "/*/*.*",
+            dir .. "/*/*/*.*",
+        }
+        for _, pat in ipairs(patterns) do
+            for _, path in ipairs(ctx.glob(pat)) do
+                local ext = ctx.extension(path)
+                if ext and VIDEO_EXTS[string.lower(ext)] and not seen_path[path] then
+                    seen_path[path] = true
+                    local filename = ctx.filename(path) or path
+                    local name = strip_ext(filename)
+                    table.insert(entries, {
+                        -- Path-scoped id keeps files in different albums
+                        -- with the same basename distinguishable.
+                        id = "video:" .. path,
+                        name = name,
+                        wp_type = "video",
+                        resource = path,
+                        -- The QML detail panel expects an image path here;
+                        -- leave video previews empty until thumbnailing exists.
+                        preview = nil,
+                        library_root = dir,
+                        metadata = {
+                            video = path,
+                            path = path,
+                        },
+                        -- Cheap stat-only metadata. Width/height/format are
+                        -- filled by the daemon's background media probe.
+                        size = ctx.file_size(path),
+                    })
+                end
+            end
+        end
+    end
+
+    ctx.log("video: found " .. #entries .. " video wallpapers in "
+            .. #dirs .. " directories")
+    return entries
+end
+
+return M

--- a/src/plugin/source_manager.rs
+++ b/src/plugin/source_manager.rs
@@ -576,4 +576,49 @@ return M
         assert_eq!(plugins.len(), 1);
         assert_eq!(plugins[0].name, "test");
     }
+
+    #[test]
+    fn video_source_plugin_discovers_video_files() {
+        let lib = tempfile::tempdir().unwrap();
+        let nested = lib.path().join("album");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(lib.path().join("clip.MP4"), b"video bytes").unwrap();
+        std::fs::write(lib.path().join("animated.gif"), b"image source owns gif").unwrap();
+        std::fs::write(nested.join("poster.png"), b"not a video").unwrap();
+        std::fs::write(nested.join("loop.webm"), b"more video bytes").unwrap();
+
+        let plugin_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("plugins/mpv/sources/video.lua");
+
+        let mut mgr = SourceManager::new().unwrap();
+        let name = mgr.load_plugin(&plugin_path).unwrap();
+        assert_eq!(name, "video");
+
+        let mut libs = HashMap::new();
+        libs.insert(
+            "video".to_string(),
+            vec![lib.path().to_string_lossy().to_string()],
+        );
+        mgr.scan_all(&libs).unwrap();
+
+        let entries = mgr.list();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.wp_type == "video"));
+        assert!(entries.iter().all(|e| e.plugin_name == "video"));
+        assert!(entries.iter().all(|e| e.preview.is_none()));
+        assert!(entries.iter().all(|e| e.size.is_some()));
+        assert!(entries.iter().all(|e| e.width.is_none()));
+        assert!(entries.iter().all(|e| e.height.is_none()));
+        assert!(entries.iter().all(|e| e.format.is_none()));
+
+        let clip_path = lib.path().join("clip.MP4").to_string_lossy().to_string();
+        let clip = mgr.get(&format!("video:{clip_path}")).unwrap();
+        assert_eq!(clip.name, "clip");
+        assert_eq!(clip.resource, clip_path);
+        assert_eq!(clip.metadata.get("video"), Some(&clip.resource));
+        assert_eq!(clip.metadata.get("path"), Some(&clip.resource));
+
+        assert_eq!(mgr.list_by_type("video").len(), 2);
+        assert!(mgr.list_by_type("image").is_empty());
+    }
 }


### PR DESCRIPTION
Adds a local video source plugin for the mpv renderer and documents local install runtime paths.