### PR TITLE
Add KDE Plasma 6 usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,27 @@ It started life as a Wallpaper Engine plugin for KDE.
 | Scene wallpapers | ✅ via [open-wallpaper-engine](https://github.com/waywallen/open-wallpaper-engine) |
 | Video wallpapers | ✅ |
 | Web wallpapers | ✅ via [open-wallpaper-engine](https://github.com/waywallen/open-wallpaper-engine) |
+
+---
+
+# NOTE: For KDE Plasma 6
+If you are using KDE Plasma 6, your display won't be detected by Waywallen.
+KDE Plasma 6 handles wallpaper completely different than older version, waywallen just ran daemon on the background and it can’t detect display layouts on it’s own in Plasma 6,
+it relies on Waywallen KDE Plasma 6 Plugin to detect display and manage the surface geometry via DMA-BUF and render wallpapers.
+
+1. Download Waywallen KDE Plasma 6 Plugin Zip files on here: https://store.kde.org/p/2356221
+2. Open Konsole, change directory to the location of the KDE Plasma 6 Plugin Zip file and run:
+```
+kpackagetool6 --type Plasma/Wallpaper -i waywallen-kde-YOUR_VERSION_HERE.zip
+```
+3. Restart Plasma Shell:
+```
+systemctl --user restart plasma-plasmashell.service
+```
+4. Go to Desktop, right click > Desktop & Wallpaper (Ctrl + Shift + D)
+<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8803764c-76a8-4936-aab9-c337773d1cf4" />
+5. Choose Wallpaper Type: Waywallen
+<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/c2d85d81-c8cf-4e96-b23a-91cf45afdf6a" />
+
+And now your Waywallen can detect your display:
+<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/3a5fc996-ec9c-47ea-81ab-ee2d24ca54be" />


### PR DESCRIPTION
Added instructions for using Waywallen with KDE Plasma 6, including plugin installation and configuration steps.

_Note:
Linux are only 4% of the desktop market share because of the user-unfriendliness, by making most app in Linux just work out of the Box, this will help Linux raise to 10% of the Market Share._