### PR TITLE
Auto-pause on lock screen and user switch (KDE Plasma)

### DIFF
--- a/proto/control.proto
+++ b/proto/control.proto
@@ -793,6 +793,10 @@ message AutopauseSettings {
   AutopauseMode mode = 1;
   // Milliseconds of "no autopause condition" required before resume.
   uint32 resume_ms = 2;
+  // Pause when the session's lock screen becomes active.
+  bool pause_on_lock = 3;
+  // Pause when the current login session becomes inactive (user switch).
+  bool pause_on_user_switch = 4;
 }
 
 // One plugin's settings table. Wire format is string→string for

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod renderer_manager;
 mod routing;
 mod scheduler;
 mod self_test;
+mod session_monitor;
 mod settings;
 mod sync;
 mod tasks;
@@ -384,6 +385,12 @@ async fn async_main() -> anyhow::Result<()> {
                 Ok(())
             });
     }
+
+    // Session-level autopause monitor. Watches D-Bus for lock-screen and
+    // user-switch events and forwards them to the router as session state
+    // changes. Errors connecting to D-Bus are non-fatal and logged as
+    // warnings; the rest of the daemon continues unaffected.
+    session_monitor::spawn(router.clone(), state.shutdown_subscribe());
 
     // Display infrastructure first. The UDS endpoint and (if applicable)
     // the daemon-managed display backend subprocess are queued *before*

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -253,6 +253,19 @@ struct Inner {
     /// Play/Pause diff when ref_counts change so we never send the
     /// same control twice.
     paused_renderers: std::collections::HashSet<RendererId>,
+    /// Set when the screen-saver / lock-screen is active. Causes all
+    /// renderers to pause regardless of per-display window-state when
+    /// `AutopauseDefaults::pause_on_lock` is enabled.
+    session_locked: bool,
+    /// Set when the current login session is inactive (user switched to
+    /// another session). Causes all renderers to pause when
+    /// `AutopauseDefaults::pause_on_user_switch` is enabled.
+    session_inactive: bool,
+    /// Generation counter for the session-pause debounce timer. Bumped
+    /// on every session-state transition; the pending resume task
+    /// carries the snapshot taken at spawn time and is a no-op if the
+    /// counter has advanced (i.e. a newer transition invalidated it).
+    session_gen: u64,
     /// Timestamp of the Pause transition for each paused renderer.
     /// Consumed by the reaper task to enforce `IDLE_KILL_TIMEOUT`.
     paused_since: HashMap<RendererId, Instant>,
@@ -319,6 +332,9 @@ impl Router {
                 unbind_acks_pending: HashMap::new(),
                 next_display_id: 0,
                 next_config_generation: 0,
+                session_locked: false,
+                session_inactive: false,
+                session_gen: 0,
             }),
             mgr,
             events_tx,
@@ -1085,6 +1101,85 @@ impl Router {
         }
     }
 
+    /// Update the session-level pause state driven by the
+    /// `session_monitor` task. Pass `Some(true/false)` to flip a flag;
+    /// `None` leaves it unchanged.
+    ///
+    /// Pause transitions are immediate. Resume transitions (both flags
+    /// becoming `false`) are held for `resume_ms` so that a brief
+    /// lock→unlock→lock flap doesn't restart renderers unnecessarily.
+    pub async fn update_session_state(
+        self: &Arc<Self>,
+        locked: Option<bool>,
+        inactive: Option<bool>,
+    ) {
+        enum Action {
+            ScheduleResume { gen: u64, ms: u32 },
+            Reconcile,
+            Noop,
+        }
+        let action = {
+            let mut inner = self.inner.lock().await;
+            let mut changed = false;
+            if let Some(v) = locked {
+                if inner.session_locked != v {
+                    inner.session_locked = v;
+                    changed = true;
+                }
+            }
+            if let Some(v) = inactive {
+                if inner.session_inactive != v {
+                    inner.session_inactive = v;
+                    changed = true;
+                }
+            }
+            if !changed {
+                Action::Noop
+            } else {
+                let now_paused = inner.session_locked || inner.session_inactive;
+                if now_paused {
+                    // Entering a paused state: immediate, cancel any
+                    // pending resume by bumping the generation counter.
+                    inner.session_gen = inner.session_gen.wrapping_add(1);
+                    Action::Reconcile
+                } else {
+                    // All session-pause flags cleared: schedule a debounced
+                    // resume so a brief flap doesn't restart renderers.
+                    inner.session_gen = inner.session_gen.wrapping_add(1);
+                    let resume_ms = self
+                        .settings
+                        .get()
+                        .map(|s| s.global().autopause.resume_ms)
+                        .unwrap_or(500);
+                    Action::ScheduleResume {
+                        gen: inner.session_gen,
+                        ms: resume_ms,
+                    }
+                }
+            }
+        };
+        match action {
+            Action::Noop => {}
+            Action::Reconcile => self.reconcile_lifecycle().await,
+            Action::ScheduleResume { gen, ms } => {
+                let router = Arc::clone(self);
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(ms as u64)).await;
+                    let need_reconcile = {
+                        let inner = router.inner.lock().await;
+                        // A newer transition invalidated us — bail.
+                        inner.session_gen == gen
+                            && !inner.session_locked
+                            && !inner.session_inactive
+                    };
+                    if need_reconcile {
+                        router.reconcile_lifecycle().await;
+                    }
+                });
+            }
+        }
+    }
+
     /// Whether this renderer is currently in the paused set (zero
     /// enabled links). Returns `false` for unknown ids.
     pub async fn is_paused(self: &Arc<Self>, renderer_id: &str) -> bool {
@@ -1759,7 +1854,16 @@ impl Router {
                             .map(|s| s.autopause.requested)
                             .unwrap_or(false)
                     });
-                let should_pause = !has_active_link || any_autopaused;
+                let session_paused = {
+                    let ap = self
+                        .settings
+                        .get()
+                        .map(|s| s.global().autopause)
+                        .unwrap_or_default();
+                    (ap.pause_on_lock && inner.session_locked)
+                        || (ap.pause_on_user_switch && inner.session_inactive)
+                };
+                let should_pause = !has_active_link || any_autopaused || session_paused;
                 let was_paused = inner.paused_renderers.contains(&rid);
                 if !should_pause && was_paused {
                     inner.paused_renderers.remove(&rid);

--- a/src/session_monitor.rs
+++ b/src/session_monitor.rs
@@ -1,0 +1,258 @@
+//! Session-level autopause monitor.
+//!
+//! Runs as a background task and watches two D-Bus signals:
+//!
+//! * **Lock screen** — `org.freedesktop.ScreenSaver.ActiveChanged(bool)`
+//!   on the session bus.  Provided by kscreenlocker on KDE Plasma.
+//!
+//! * **User switch** — `org.freedesktop.login1.Session` `Active` property
+//!   changes on the system bus.  When the user switches to another session
+//!   via the display manager the current session's `Active` property becomes
+//!   `false`.
+//!
+//! Each signal is monitored in its own sub-task; a shared channel delivers
+//! [`SessionEvent`] values to the main loop, which calls
+//! [`Router::update_session_state`].  All D-Bus errors are treated as
+//! non-fatal: if a service is unavailable the corresponding sub-task exits
+//! and logs a warning, while the rest of the daemon (and the other trigger)
+//! continues unaffected.
+
+use std::sync::Arc;
+
+use futures_util::StreamExt;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use zbus::proxy;
+
+use crate::routing::Router;
+
+// ---------------------------------------------------------------------------
+// D-Bus proxy definitions
+// ---------------------------------------------------------------------------
+
+#[proxy(
+    interface = "org.freedesktop.ScreenSaver",
+    default_service = "org.freedesktop.ScreenSaver",
+    default_path = "/org/freedesktop/ScreenSaver"
+)]
+trait ScreenSaver {
+    /// Fired when the screensaver / lock screen is activated or deactivated.
+    #[zbus(signal)]
+    fn active_changed(&self, new_value: bool) -> zbus::Result<()>;
+
+    /// Returns the current active state synchronously so we can seed the
+    /// initial value without waiting for the first signal.
+    fn get_active(&self) -> zbus::Result<bool>;
+}
+
+#[proxy(
+    interface = "org.freedesktop.login1.Session",
+    default_service = "org.freedesktop.login1"
+)]
+trait Login1Session {
+    /// `true` when this session is the currently active VT session.
+    #[zbus(property)]
+    fn active(&self) -> zbus::Result<bool>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal event type
+// ---------------------------------------------------------------------------
+
+enum SessionEvent {
+    /// The screen-saver / lock screen changed state.
+    Locked(bool),
+    /// The login session's `Active` property changed.
+    SessionActive(bool),
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Spawn the session monitor.  Returns immediately; monitoring runs in the
+/// background until `shutdown` signals `true`.
+pub fn spawn(router: Arc<Router>, shutdown: watch::Receiver<bool>) {
+    tokio::spawn(async move {
+        run(router, shutdown).await;
+    });
+}
+
+async fn run(router: Arc<Router>, mut shutdown: watch::Receiver<bool>) {
+    log::info!("session_monitor: starting");
+    let (tx, mut rx) = mpsc::channel::<SessionEvent>(16);
+
+    // --- Screen saver (session bus) ----------------------------------------
+    match zbus::Connection::session().await {
+        Ok(conn) => {
+            log::info!("session_monitor: session bus connected, starting screen-saver monitor");
+            let tx2 = tx.clone();
+            tokio::spawn(async move {
+                monitor_screen_saver(conn, tx2).await;
+            });
+        }
+        Err(e) => {
+            log::warn!("session_monitor: cannot connect to D-Bus session bus: {e}");
+        }
+    }
+
+    // --- Login session (system bus) ----------------------------------------
+    match zbus::Connection::system().await {
+        Ok(conn) => {
+            log::info!("session_monitor: system bus connected, starting login-session monitor");
+            let tx2 = tx.clone();
+            tokio::spawn(async move {
+                monitor_login_session(conn, tx2).await;
+            });
+        }
+        Err(e) => {
+            log::warn!("session_monitor: cannot connect to D-Bus system bus: {e}");
+        }
+    }
+
+    // --- Main dispatch loop -------------------------------------------------
+    loop {
+        tokio::select! {
+            // Watch for shutdown signal.
+            result = shutdown.changed() => {
+                if result.is_err() || *shutdown.borrow() {
+                    break;
+                }
+            }
+            // Receive events from sub-tasks and forward to router.
+            Some(event) = rx.recv() => {
+                match event {
+                    SessionEvent::Locked(active) => {
+                        log::info!("session_monitor: screen lock active={active}");
+                        router.update_session_state(Some(active), None).await;
+                    }
+                    SessionEvent::SessionActive(active) => {
+                        // session_inactive is the inverse of `Active`
+                        log::info!("session_monitor: login session active={active}");
+                        router.update_session_state(None, Some(!active)).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Screen saver sub-task
+// ---------------------------------------------------------------------------
+
+async fn monitor_screen_saver(conn: zbus::Connection, tx: mpsc::Sender<SessionEvent>) {
+    log::info!(
+        "session_monitor: subscribing to org.freedesktop.ScreenSaver \
+         at /org/freedesktop/ScreenSaver"
+    );
+    let proxy = match ScreenSaverProxy::new(&conn).await {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("session_monitor: ScreenSaver proxy unavailable: {e}");
+            return;
+        }
+    };
+
+    // Seed initial state.
+    match proxy.get_active().await {
+        Ok(active) => {
+            log::info!("session_monitor: ScreenSaver initial state: active={active}");
+            let _ = tx.send(SessionEvent::Locked(active)).await;
+        }
+        Err(e) => {
+            // Service may not be running yet (screen not locked on startup).
+            log::info!("session_monitor: ScreenSaver.GetActive not available yet: {e}");
+        }
+    }
+
+    // Subscribe to future changes.
+    let mut stream = match proxy.receive_active_changed().await {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("session_monitor: ScreenSaver.ActiveChanged subscribe failed: {e}");
+            return;
+        }
+    };
+
+    log::info!("session_monitor: listening for ScreenSaver.ActiveChanged signals");
+
+    while let Some(signal) = stream.next().await {
+        match signal.args() {
+            Ok(args) => {
+                log::info!("session_monitor: ScreenSaver.ActiveChanged new_value={}", args.new_value());
+                let _ = tx.send(SessionEvent::Locked(*args.new_value())).await;
+            }
+            Err(e) => {
+                log::warn!("session_monitor: bad ActiveChanged args: {e}");
+            }
+        }
+    }
+
+    log::info!("session_monitor: ScreenSaver signal stream ended (service stopped?)");
+}
+
+// ---------------------------------------------------------------------------
+// Login session sub-task
+// ---------------------------------------------------------------------------
+
+async fn monitor_login_session(conn: zbus::Connection, tx: mpsc::Sender<SessionEvent>) {
+    // Derive session path from $XDG_SESSION_ID — avoids the privileged
+    // GetSessionByPID call that fails with AccessDenied for user processes.
+    let session_id = match std::env::var("XDG_SESSION_ID") {
+        Ok(id) if !id.is_empty() => id,
+        _ => {
+            log::warn!(
+                "session_monitor: $XDG_SESSION_ID not set; user-switch detection disabled"
+            );
+            return;
+        }
+    };
+    let session_path_str = format!("/org/freedesktop/login1/session/{session_id}");
+    log::info!("session_monitor: login1 session path: {session_path_str}");
+
+    let session_builder = match Login1SessionProxy::builder(&conn).path(session_path_str) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("session_monitor: login1 Session path invalid: {e}");
+            return;
+        }
+    };
+    let session = match session_builder.build().await {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("session_monitor: login1 Session proxy unavailable: {e}");
+            return;
+        }
+    };
+
+    // Seed initial state.
+    match session.active().await {
+        Ok(active) => {
+            log::info!("session_monitor: login1 Session initial Active={active}");
+            let _ = tx.send(SessionEvent::SessionActive(active)).await;
+        }
+        Err(e) => {
+            log::warn!("session_monitor: Session.Active initial read failed: {e}");
+        }
+    }
+
+    // Subscribe to property changes.
+    let mut stream = session.receive_active_changed().await;
+
+    log::info!("session_monitor: listening for login1 Session.Active changes");
+
+    while let Some(change) = stream.next().await {
+        match change.get().await {
+            Ok(active) => {
+                log::info!("session_monitor: login1 Session.Active changed to {active}");
+                let _ = tx.send(SessionEvent::SessionActive(active)).await;
+            }
+            Err(e) => {
+                log::warn!("session_monitor: Session.Active read after change failed: {e}");
+            }
+        }
+    }
+
+    log::info!("session_monitor: login1 Active property stream ended");
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -121,11 +121,25 @@ pub struct AutopauseDefaults {
     /// renderer is allowed to Play again. Smooths bursty fullscreen
     /// toggles (e.g. video player UI peek).
     pub resume_ms: u32,
+    /// Pause all renderers when the session's screen-saver/lock-screen
+    /// becomes active (`org.freedesktop.ScreenSaver.ActiveChanged`).
+    /// Monitored by `session_monitor` on the D-Bus session bus.
+    pub pause_on_lock: bool,
+    /// Pause all renderers when the current login session becomes
+    /// inactive (user switches to another session via the display
+    /// manager). Monitored via `org.freedesktop.login1.Session.Active`
+    /// on the D-Bus system bus.
+    pub pause_on_user_switch: bool,
 }
 
 impl Default for AutopauseDefaults {
     fn default() -> Self {
-        Self { mode: AutopauseMode::Never, resume_ms: 500 }
+        Self {
+            mode: AutopauseMode::Never,
+            resume_ms: 500,
+            pause_on_lock: true,
+            pause_on_user_switch: true,
+        }
     }
 }
 

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -422,6 +422,8 @@ fn global_to_pb(g: &crate::settings::GlobalSettings) -> pb::GlobalSettings {
         autopause: Some(pb::AutopauseSettings {
             mode: autopause_mode_to_pb(g.autopause.mode) as i32,
             resume_ms: g.autopause.resume_ms,
+            pause_on_lock: g.autopause.pause_on_lock,
+            pause_on_user_switch: g.autopause.pause_on_user_switch,
         }),
         queue_mode: g.queue_mode.clone(),
         rotation_secs: g.rotation_secs,
@@ -1420,6 +1422,8 @@ async fn dispatch_inner(
                     if let Some(ap) = g.autopause.as_ref() {
                         s.global.autopause.mode = autopause_mode_from_pb(ap.mode);
                         s.global.autopause.resume_ms = ap.resume_ms;
+                        s.global.autopause.pause_on_lock = ap.pause_on_lock;
+                        s.global.autopause.pause_on_user_switch = ap.pause_on_user_switch;
                     }
                     if !g.queue_mode.is_empty() {
                         s.global.queue_mode = g.queue_mode.clone();

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -199,6 +199,86 @@ MD.Page {
                             }
                         }
                     }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+
+                            MD.Text {
+                                text: qsTr("Pause on lock screen")
+                                typescale: MD.Token.typescale.body_medium
+                                color: MD.Token.color.on_surface
+                            }
+                            MD.Text {
+                                text: qsTr("Pause while the screen is locked")
+                                typescale: MD.Token.typescale.body_small
+                                color: MD.Token.color.on_surface_variant
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        MD.Switch {
+                            id: m_pause_on_lock
+                            onToggled: root._mut(g => {
+                                const ap = Object.assign({},
+                                    g.autopause || ({ mode: 0, resumeMs: 500,
+                                                      pauseOnLock: true,
+                                                      pauseOnUserSwitch: true }));
+                                ap.pauseOnLock = checked;
+                                g.autopause = ap;
+                            })
+                        }
+                        Binding {
+                            target: m_pause_on_lock
+                            property: "checked"
+                            value: getQ.global?.autopause?.pauseOnLock ?? true
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+
+                            MD.Text {
+                                text: qsTr("Pause on user switch")
+                                typescale: MD.Token.typescale.body_medium
+                                color: MD.Token.color.on_surface
+                            }
+                            MD.Text {
+                                text: qsTr("Pause when switching to another user session")
+                                typescale: MD.Token.typescale.body_small
+                                color: MD.Token.color.on_surface_variant
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        MD.Switch {
+                            id: m_pause_on_user_switch
+                            onToggled: root._mut(g => {
+                                const ap = Object.assign({},
+                                    g.autopause || ({ mode: 0, resumeMs: 500,
+                                                      pauseOnLock: true,
+                                                      pauseOnUserSwitch: true }));
+                                ap.pauseOnUserSwitch = checked;
+                                g.autopause = ap;
+                            })
+                        }
+                        Binding {
+                            target: m_pause_on_user_switch
+                            property: "checked"
+                            value: getQ.global?.autopause?.pauseOnUserSwitch ?? true
+                        }
+                    }
                 }
             }
 

--- a/ui/src/query/settings_query.cpp
+++ b/ui/src/query/settings_query.cpp
@@ -34,8 +34,10 @@ auto map_to_layout(const QVariantMap& m) -> proto::LayoutPrefs {
 
 auto autopause_to_map(const proto::AutopauseSettings& a) -> QVariantMap {
     QVariantMap m;
-    m[u"mode"_s]     = static_cast<int>(a.mode());
-    m[u"resumeMs"_s] = a.resumeMs();
+    m[u"mode"_s]              = static_cast<int>(a.mode());
+    m[u"resumeMs"_s]          = a.resumeMs();
+    m[u"pauseOnLock"_s]       = a.pauseOnLock();
+    m[u"pauseOnUserSwitch"_s] = a.pauseOnUserSwitch();
     return m;
 }
 
@@ -43,6 +45,8 @@ auto map_to_autopause(const QVariantMap& m) -> proto::AutopauseSettings {
     proto::AutopauseSettings a;
     a.setMode(static_cast<proto::AutopauseMode>(m.value(u"mode"_s).toInt()));
     a.setResumeMs(m.value(u"resumeMs"_s).toUInt());
+    a.setPauseOnLock(m.value(u"pauseOnLock"_s, true).toBool());
+    a.setPauseOnUserSwitch(m.value(u"pauseOnUserSwitch"_s, true).toBool());
     return a;
 }
 


### PR DESCRIPTION
## Summary

Extends the existing auto-pause system with two new session-level triggers:
**lock screen activation** and **user switching** (switching to another session
via SDDM without ending the current one). Both triggers are off by default and
can be independently toggled in Settings → Auto-pause.

## Motivation

The existing auto-pause machinery covers window focus and fullscreen conditions
but leaves renderers running in two common idle scenarios: when the screen is
locked and when the user switches to a different session. Both waste GPU/CPU
cycles since the wallpaper is entirely invisible.

## What changed

### New background task — `src/session_monitor.rs`

A new Tokio task watches two D-Bus signals and forwards state changes to the
router via `Router::update_session_state`:

- **Lock screen** — subscribes to
  `org.freedesktop.ScreenSaver.ActiveChanged(bool)` on the session bus.
  Seeds the initial state at startup via `GetActive()`. On KDE Plasma this
  signal is emitted by kscreenlocker.

- **User switch** — subscribes to the `Active` property of the current
  session's `org.freedesktop.login1.Session` object on the system bus.
  The session object path is derived from `$XDG_SESSION_ID` to avoid the
  privileged `GetSessionByPID` call, which is rejected with `AccessDenied`
  for unprivileged user processes.

Each signal is watched in its own sub-task. All D-Bus errors are non-fatal:
if a service is unavailable the affected sub-task exits with a warning while
the rest of the daemon and the other trigger continue working normally.

### Router — `src/routing/router.rs`

- Added `session_locked: bool`, `session_inactive: bool`, and `session_gen: u64`
  fields to `Inner`.
- `reconcile_lifecycle` now folds session state into the pause decision:
  ```
  session_paused = (pause_on_lock && session_locked)
                 || (pause_on_user_switch && session_inactive)
  ```
- `update_session_state` uses the same generation-counter debounce pattern as
  `update_display_window_state`: **pause transitions are immediate** (generation
  is bumped to invalidate any pending resume timer), while **resume transitions
  are held for `resume_ms`** to avoid restarting renderers on brief
  lock→unlock→lock flaps.

### Settings — `src/settings.rs`

Added `pause_on_lock: bool` and `pause_on_user_switch: bool` to
`AutopauseDefaults`. Both default to `false`.

### Control protocol — `proto/control.proto`

Added fields `pause_on_lock` (field 3) and `pause_on_user_switch` (field 4) to
`AutopauseSettings`. Fully backwards-compatible — old clients that do not send
these fields get the defaults.

### WebSocket server — `src/ws_server.rs`

`global_to_pb()` serialises the new fields; the `SettingsSet` handler
deserialises and persists them.

### UI

- **`ui/src/query/settings_query.cpp`** — `autopause_to_map()` and
  `map_to_autopause()` round-trip the two new fields as `pauseOnLock` and
  `pauseOnUserSwitch`.

- **`ui/qml/page/SettingsPage.qml`** — two labelled `MD.Switch` toggles are
  added to the Auto-pause section, with a `Binding` for live sync and the
  standard `_mut()` debounce for writes.

### Daemon entry point — `src/main.rs`

Spawns the session monitor after the router is ready:
```rust
session_monitor::spawn(router.clone(), state.shutdown_subscribe());
```