### PR TITLE
Set desktop file name for ui

### DIFF
--- a/ui/src/main.cpp
+++ b/ui/src/main.cpp
@@ -9,6 +9,7 @@ import waywallen;
 int main(int argc, char** argv) {
     ncrequest::global_init();
     QGuiApplication gui_app(argc, argv);
+    QGuiApplication::setDesktopFileName(APP_ID);
     QCoreApplication::setApplicationName(APP_NAME);
     QCoreApplication::setApplicationVersion(APP_VERSION);
 


### PR DESCRIPTION
This fixes that the taskbar icon of ui is missing on KDE Wayland.