### PR TITLE
style: cargo fmt over files touched in #53

### DIFF
--- a/displays/layer-shell/src/hyprland_watcher.rs
+++ b/displays/layer-shell/src/hyprland_watcher.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use waywallen::display::proto::{codec, Request as ProtoRequest};
 use crate::OutputBinding;
+use waywallen::display::proto::{codec, Request as ProtoRequest};
 use waywallen::routing::autopause::{
     FLAG_ACTIVE, FLAG_FULLSCREEN, FLAG_MAXIMIZED, FLAG_NON_MINIMIZED,
 };
@@ -73,17 +73,9 @@ fn push_state(registry: &BindingRegistry) {
         }
     };
     let by_output = aggregate_flags(&snapshot);
-    let bindings: Vec<Arc<OutputBinding>> = registry
-        .lock()
-        .unwrap()
-        .values()
-        .cloned()
-        .collect();
+    let bindings: Vec<Arc<OutputBinding>> = registry.lock().unwrap().values().cloned().collect();
     for binding in bindings {
-        let flags = by_output
-            .get(binding.display_name())
-            .copied()
-            .unwrap_or(0);
+        let flags = by_output.get(binding.display_name()).copied().unwrap_or(0);
         let prev = binding.window_flags().swap(flags, Ordering::SeqCst);
         if prev == flags {
             continue;
@@ -170,8 +162,11 @@ fn run_hyprctl_json<T: serde::de::DeserializeOwned>(args: &[&str]) -> anyhow::Re
 }
 
 fn aggregate_flags(snap: &Snapshot) -> HashMap<String, u32> {
-    let mon_name: HashMap<i64, String> =
-        snap.monitors.iter().map(|m| (m.id, m.name.clone())).collect();
+    let mon_name: HashMap<i64, String> = snap
+        .monitors
+        .iter()
+        .map(|m| (m.id, m.name.clone()))
+        .collect();
     let active_ws: HashMap<i64, i64> = snap
         .monitors
         .iter()

--- a/displays/layer-shell/src/main.rs
+++ b/displays/layer-shell/src/main.rs
@@ -1270,8 +1270,7 @@ fn run_uds_session(sock: &Path, binding: &OutputBinding) -> Result<()> {
     let mut transform_dirty: bool = true;
 
     loop {
-        let (evt, mut fds) =
-            codec::recv_event(stream).map_err(|e| anyhow!("recv event: {e}"))?;
+        let (evt, mut fds) = codec::recv_event(stream).map_err(|e| anyhow!("recv event: {e}"))?;
         match evt {
             ProtoEvent::BindBuffers {
                 buffer_generation,
@@ -1416,9 +1415,7 @@ fn run_uds_session(sock: &Path, binding: &OutputBinding) -> Result<()> {
                         }
 
                         if transform_dirty {
-                            binding
-                                .surface
-                                .set_buffer_transform(Transform::Normal);
+                            binding.surface.set_buffer_transform(Transform::Normal);
                             transform_dirty = false;
                         }
 

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -497,9 +497,7 @@ impl Router {
         clear: bool,
     ) {
         let Some(settings) = self.settings.get().cloned() else {
-            log::warn!(
-                "router: set_display_alias({display_name}) called before settings attached"
-            );
+            log::warn!("router: set_display_alias({display_name}) called before settings attached");
             return;
         };
         let target_id = self.find_display_by_name(&display_name).await;

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -801,7 +801,11 @@ async fn dispatch_inner(
         Req::WallpaperList(r) => {
             log::info!(
                 "WallpaperList: page={} page_size={} wp_type={:?} filters={} search={:?}",
-                r.page, r.page_size, r.wp_type, r.filters.len(), r.search_text
+                r.page,
+                r.page_size,
+                r.wp_type,
+                r.filters.len(),
+                r.search_text
             );
             // Read from the snapshot mirror (see `source_snapshot.rs`)
             // so an in-flight scan does not block this query.
@@ -883,9 +887,7 @@ async fn dispatch_inner(
             } else {
                 ((r.page as usize) * page_size, page_size)
             };
-            log::info!(
-                "WallpaperList: total={total} returning offset={offset} take={take}"
-            );
+            log::info!("WallpaperList: total={total} returning offset={offset} take={take}");
 
             let page_entries: Vec<&crate::wallpaper_type::WallpaperEntry> = filtered_entries
                 .into_iter()


### PR DESCRIPTION
The Format job started failing on `main` after #53 landed - a few log macro calls and a small `let ... = if ... { ... } else { ... };` block came through with a layout that `cargo fmt` flattens. Running `cargo fmt --all` over the files I changed in #53 fixes the diff so CI goes green again.

Pure formatting, no behavioural change. Builds cleanly with `cmake --build build/clang-release` locally.