### PR TITLE
Add a discover page prepared for in-app workshop browser

### DIFF
--- a/proto/control.proto
+++ b/proto/control.proto
@@ -67,6 +67,11 @@ message Request {
     PluginListRequest         plugin_list = 47;
     TagListRequest            tag_list = 48;
     ContentRatingListRequest  content_rating_list = 49;
+    RemoteAvailabilityRequest remote_availability = 50;
+    RemoteSearchRequest       remote_search = 51;
+    RemoteDownloadRequest     remote_download = 52;
+    RemoteUninstallRequest    remote_uninstall = 53;
+    RemoteDetailsRequest      remote_details = 54;
   }
 }
 
@@ -121,6 +126,11 @@ message Response {
     PluginListResponse         plugin_list = 47;
     TagListResponse            tag_list = 48;
     ContentRatingListResponse  content_rating_list = 49;
+    RemoteAvailabilityResponse remote_availability = 50;
+    RemoteSearchResponse       remote_search = 51;
+    RemoteDownloadResponse     remote_download = 52;
+    RemoteUninstallResponse    remote_uninstall = 53;
+    RemoteDetailsResponse      remote_details = 54;
   }
 }
 
@@ -566,6 +576,73 @@ message DisplayRenameResponse {
   DisplayInfo display = 1;
 }
 
+message RemoteAvailabilityRequest {}
+message RemoteAvailabilityResponse {
+  bool   owned = 1;
+  string content_dir = 2;
+}
+
+enum RemoteSort {
+  REMOTE_SORT_UNSPECIFIED = 0;
+  REMOTE_SORT_TREND = 1;
+  REMOTE_SORT_RECENT = 2;
+  REMOTE_SORT_POPULAR = 3;
+}
+
+message RemoteItem {
+  string id = 1;
+  string title = 2;
+  string preview_url = 3;
+  string author = 4;
+  bool   installed = 5;
+}
+
+message RemoteSearchRequest {
+  string query = 1;
+  RemoteSort sort = 2;
+  uint32 page = 3;
+  repeated string required_tags = 4;
+}
+message RemoteSearchResponse {
+  repeated RemoteItem items = 1;
+  bool   has_more = 2;
+  string error = 3;
+}
+
+message RemoteDownloadRequest { string id = 1; }
+message RemoteDownloadResponse {
+  bool   accepted = 1;
+  string error = 2;
+}
+
+message RemoteUninstallRequest { string id = 1; }
+message RemoteUninstallResponse {
+  bool   removed = 1;
+  string error = 2;
+}
+
+message RemoteDetailsRequest { string id = 1; }
+message RemoteDetailsResponse {
+  string description = 1;
+  string size = 2;
+  repeated string tags = 3;
+  string error = 4;
+}
+
+enum RemoteDownloadState {
+  REMOTE_DOWNLOAD_STATE_UNSPECIFIED = 0;
+  REMOTE_DOWNLOAD_STATE_PENDING = 1;
+  REMOTE_DOWNLOAD_STATE_DOWNLOADING = 2;
+  REMOTE_DOWNLOAD_STATE_DONE = 3;
+  REMOTE_DOWNLOAD_STATE_TIMEOUT = 4;
+  REMOTE_DOWNLOAD_STATE_ERROR = 5;
+}
+message RemoteDownloadProgress {
+  string id = 1;
+  RemoteDownloadState state = 2;
+  string error = 3;
+}
+
 message DisplayListRequest {}
 message DisplayListResponse {
   repeated DisplayInfo displays = 1;
@@ -660,6 +737,7 @@ message Event {
     StatusSync             status_sync               = 13;
     SettingsChanged        settings_changed          = 14;
     DisplayConnectionFailed display_connection_failed = 15;
+    RemoteDownloadProgress remote_download_progress = 16;
   }
 }
 

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -1235,6 +1235,34 @@ async fn dispatch_inner(
             Res::DisplayRename(pb::DisplayRenameResponse { display })
         }
 
+        Req::RemoteAvailability(_) => Res::RemoteAvailability(pb::RemoteAvailabilityResponse {
+            owned: false,
+            content_dir: String::new(),
+        }),
+
+        Req::RemoteSearch(_) => Res::RemoteSearch(pb::RemoteSearchResponse {
+            items: Vec::new(),
+            has_more: false,
+            error: String::new(),
+        }),
+
+        Req::RemoteDownload(_) => Res::RemoteDownload(pb::RemoteDownloadResponse {
+            accepted: false,
+            error: "no remote source plugin".into(),
+        }),
+
+        Req::RemoteUninstall(_) => Res::RemoteUninstall(pb::RemoteUninstallResponse {
+            removed: false,
+            error: "no remote source plugin".into(),
+        }),
+
+        Req::RemoteDetails(_) => Res::RemoteDetails(pb::RemoteDetailsResponse {
+            description: String::new(),
+            size: String::new(),
+            tags: Vec::new(),
+            error: String::new(),
+        }),
+
         Req::WallpaperApply(r) => {
             let entry = match r.wallpaper_id.parse::<i64>() {
                 Ok(iid) => repo::get_entry(&state.db, iid).await?,

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SOURCES_NO_MOC
   src/msg/store.cpp
   src/model/store_item.cpp
   src/model/list_models.cpp
+  src/model/remote_model.cpp
   src/model/filter_rule_model.cpp
   src/model/user_property_model.cpp
   src/query/wallpaper_query.cpp
@@ -80,6 +81,7 @@ set(SOURCES_NO_MOC
   src/query/gpu_query.cpp
   src/query/library_query.cpp
   src/query/settings_query.cpp
+  src/query/remote_query.cpp
   src/thumb/service.cpp
 )
 
@@ -101,6 +103,7 @@ set(MOC_SOURCE_FILES
   src/msg/store.cppm
   src/model/store_item.cppm
   src/model/list_models.cppm
+  src/model/remote_model.cppm
   src/model/filter_rule_model.cppm
   src/model/user_property_model.cppm
   src/query/wallpaper_query.cppm
@@ -113,6 +116,7 @@ set(MOC_SOURCE_FILES
   src/query/gpu_query.cppm
   src/query/library_query.cppm
   src/query/settings_query.cppm
+  src/query/remote_query.cppm
   src/thumb/service.cppm
 )
 set(MODULES
@@ -145,8 +149,11 @@ set(QML_FILES
   qml/component/settings/SettingField.qml
   qml/dialog/DaemonNotRunDialog.qml
   qml/dialog/WallpaperFilterDialog.qml
+  qml/dialog/RemoteFilterDialog.qml
   qml/page/WallpaperPage.qml
   qml/page/WallpaperCard.qml
+  qml/page/DiscoverPage.qml
+  qml/page/RemoteCard.qml
   qml/page/StatusPage.qml
   qml/page/PluginManagePage.qml
   qml/page/SettingsPage.qml

--- a/ui/qml/Window.qml
+++ b/ui/qml/Window.qml
@@ -40,33 +40,36 @@ MD.ApplicationWindow {
         target: W.Notify
         function onDaemonReady() {
             healthQuery.reload();
+            remoteAvail.reload();
         }
+    }
+
+    W.RemoteAvailabilityQuery {
+        id: remoteAvail
     }
 
     property int currentPage: 0
 
     readonly property bool isCompact: MD.MProp.size.isCompact
 
-    readonly property var pageModel: [
-        {
-            icon: MD.Token.icon.wallpaper,
-            name: "Wallpapers"
-        },
-        {
-            icon: MD.Token.icon.monitor,
-            name: "Displays"
-        },
-        {
-            icon: MD.Token.icon.monitor_heart,
-            name: "Status"
-        }
+    readonly property var basePageModel: [
+        { icon: MD.Token.icon.wallpaper, name: "Wallpapers" },
+        { icon: MD.Token.icon.monitor, name: "Displays" },
+        { icon: MD.Token.icon.monitor_heart, name: "Status" }
     ]
+    readonly property var discoverPageEntry: ({ icon: MD.Token.icon.search, name: "Discover" })
+    readonly property var pageModel: remoteAvail.owned
+        ? basePageModel.slice(0, 2).concat([discoverPageEntry], basePageModel.slice(2))
+        : basePageModel
 
-    readonly property var pageComponents: ["qrc:/waywallen/ui/qml/page/WallpaperPage.qml", "qrc:/waywallen/ui/qml/page/DisplaysPage.qml", "qrc:/waywallen/ui/qml/page/StatusPage.qml",]
-    // Pages that should survive navigation. Wallpapers carries scroll
-    // position, selection, and a non-trivial list query — recreating it
-    // on every visit causes a visible reload churn.
-    readonly property var pageCacheable: [true, false, false]
+    readonly property var basePageComponents: ["qrc:/waywallen/ui/qml/page/WallpaperPage.qml", "qrc:/waywallen/ui/qml/page/DisplaysPage.qml", "qrc:/waywallen/ui/qml/page/StatusPage.qml"]
+    readonly property var pageComponents: remoteAvail.owned
+        ? basePageComponents.slice(0, 2).concat(["qrc:/waywallen/ui/qml/page/DiscoverPage.qml"], basePageComponents.slice(2))
+        : basePageComponents
+
+    readonly property var pageCacheable: remoteAvail.owned
+        ? [true, false, true, false]
+        : [true, false, false]
 
     onCurrentPageChanged: {
         m_content.switchTo(pageComponents[currentPage], {}, pageCacheable[currentPage]);
@@ -78,8 +81,10 @@ MD.ApplicationWindow {
         // before this window finishes constructing (UI launched
         // standalone against a running daemon, page reload, etc.)
         // — `daemonReady` is edge-triggered and won't fire then.
-        if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready)
+        if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready) {
             healthQuery.reload();
+            remoteAvail.reload();
+        }
     }
 
     MD.SnakeView {

--- a/ui/qml/dialog/RemoteFilterDialog.qml
+++ b/ui/qml/dialog/RemoteFilterDialog.qml
@@ -1,0 +1,146 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Templates as T
+import Qcm.Material as MD
+
+MD.Dialog {
+    id: root
+    title: qsTr("Filters")
+    horizontalPadding: 16
+    implicitWidth: Math.min(760, parent ? parent.width - 48 : 760)
+    standardButtons: T.Dialog.Cancel | T.Dialog.Reset | T.Dialog.Apply
+
+    signal apply(var tags)
+
+    readonly property var defaults: ({ "Scene": true, "Video": true, "Web": true, "Application": true })
+    property var working: cloneDefaults()
+
+    readonly property var groups: [
+        { name: qsTr("Type"), tags: ["Scene", "Video", "Web", "Application"] },
+        { name: qsTr("Genre"), tags: ["Abstract", "Animal", "Anime", "Cartoon", "CG",
+            "Cyberpunk", "Fantasy", "Game", "Girls", "Guys", "Landscape", "Medieval",
+            "Memes", "MMD", "Music", "Nature", "Pixel art", "Relaxing", "Retro",
+            "Sci-Fi", "Sports", "Technology", "Vehicle", "Unspecified"] },
+        { name: qsTr("Resolution"), tags: ["1280 x 720", "1920 x 1080", "2560 x 1440",
+            "3840 x 2160", "2560 x 1080", "3440 x 1440", "5120 x 1440", "3840 x 1080",
+            "7680 x 2160", "1080 x 1920", "720 x 1280", "1440 x 2560"] },
+        { name: qsTr("Misc"), tags: ["Audio Responsive", "Customizable", "Come with Music"] }
+    ]
+
+    function cloneDefaults() {
+        let w = {};
+        for (const k in defaults)
+            w[k] = defaults[k];
+        return w;
+    }
+    function has(tag) {
+        return working[tag] === true;
+    }
+    function toggle(tag, on) {
+        let w = working;
+        if (on)
+            w[tag] = true;
+        else
+            delete w[tag];
+        working = w;
+    }
+    function collect() {
+        let out = [];
+        for (const g of groups) {
+            let checkedIn = g.tags.filter(t => working[t] === true);
+            if (checkedIn.length > 0 && checkedIn.length < g.tags.length)
+                out = out.concat(checkedIn);
+        }
+        if (working["Mature"] !== true)
+            out.push("Everyone");
+        return out;
+    }
+
+    onApplied: {
+        root.apply(collect());
+        accept();
+    }
+    onReset: working = cloneDefaults()
+
+    contentItem: ColumnLayout {
+        spacing: 16
+
+        Repeater {
+            model: root.groups
+            delegate: ColumnLayout {
+                id: groupCol
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: 6
+
+                MD.Label {
+                    text: groupCol.modelData.name
+                    typescale: MD.Token.typescale.title_small
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    Repeater {
+                        model: groupCol.modelData.tags
+                        delegate: MD.FilterChip {
+                            required property string modelData
+                            text: modelData
+                            checked: root.has(modelData)
+                            onClicked: root.toggle(modelData, checked)
+                        }
+                    }
+                }
+            }
+        }
+
+        MD.Divider { Layout.fillWidth: true }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+                MD.Label {
+                    text: qsTr("Mature content (NSFW)")
+                    typescale: MD.Token.typescale.title_small
+                }
+                MD.Label {
+                    text: qsTr("18+ only. Shows mature-tagged wallpapers.")
+                    typescale: MD.Token.typescale.body_small
+                    color: MD.Token.color.on_surface_variant
+                }
+            }
+
+            MD.Switch {
+                id: m_nsfw
+                checked: root.has("Mature")
+                onClicked: {
+                    if (!root.has("Mature"))
+                        m_confirm.open();
+                    else
+                        root.toggle("Mature", false);
+                }
+            }
+        }
+    }
+
+    MD.Dialog {
+        id: m_confirm
+        title: qsTr("Mature content")
+        modal: true
+        anchors.centerIn: T.Overlay.overlay
+        standardButtons: T.Dialog.Cancel | T.Dialog.Ok
+        onAccepted: root.toggle("Mature", true)
+        onRejected: m_nsfw.checked = Qt.binding(() => root.has("Mature"))
+
+        contentItem: MD.Label {
+            text: qsTr("This shows wallpapers tagged as mature / NSFW. You must be 18 or older to enable this. Continue?")
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/ui/qml/page/DiscoverPage.qml
+++ b/ui/qml/page/DiscoverPage.qml
@@ -1,0 +1,434 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Templates as T
+import Qcm.Material as MD
+import waywallen.ui as W
+
+MD.Page {
+    id: root
+    showBackground: false
+    padding: MD.MProp.size.isCompact ? 0 : 12
+
+    property var detailRow: null
+    property int detailState: 0
+
+    readonly property var sortOptions: [
+        { name: qsTr("Trending"), value: 1 },
+        { name: qsTr("Recent"), value: 2 },
+        { name: qsTr("Popular"), value: 3 }
+    ]
+    property int sortIndex: 0
+
+    function pickSort(idx) {
+        sortIndex = idx;
+        searchQuery.sort = sortOptions[idx].value;
+    }
+
+    function selectItem(index) {
+        detailRow = searchQuery.model.get(index);
+        detailState = detailRow.installed ? 3 : 0;
+        detailsQuery.itemId = detailRow.itemId;
+    }
+
+    function fmtSize(s) {
+        const m = String(s).match(/^([\d.,]+)\s*([KMGT]?B)$/i);
+        if (!m)
+            return s;
+        const num = parseFloat(m[1].replace(/,/g, ""));
+        if (isNaN(num))
+            return s;
+        const unit = m[2].toUpperCase();
+        return num.toFixed(unit === "B" ? 0 : 1) + " " + unit;
+    }
+
+    W.RemoteSearchQuery {
+        id: searchQuery
+        sort: 1
+        onStateChanged: {
+            if (errorText.length > 0)
+                W.Action.toast(qsTr("Remote search failed: ") + errorText);
+        }
+    }
+
+    W.RemoteFilterDialog {
+        id: m_filter_dialog
+        parent: T.Overlay.overlay
+        anchors.centerIn: parent
+        onApply: function(tags) {
+            searchQuery.tags = tags;
+        }
+    }
+
+    W.RemoteDetailsQuery {
+        id: detailsQuery
+    }
+
+    W.RemoteDownloadQuery {
+        id: dlQuery
+        function onUninstalled(id) {
+            searchQuery.model.setInstalled(id, false);
+            if (root.detailRow && root.detailRow.itemId === id) {
+                root.detailRow.installed = false;
+                root.detailState = 0;
+            }
+            W.Action.toast(qsTr("Uninstalled"));
+        }
+        function onUninstallFailed(id, error) {
+            W.Action.toast(qsTr("Uninstall failed: ") + error);
+        }
+        function onRejected(id, error) {
+            if (root.detailRow && root.detailRow.itemId === id)
+                root.detailState = 0;
+            W.Action.toast(qsTr("Download rejected: ") + error);
+        }
+    }
+
+    Connections {
+        target: W.Notify
+        function onRemoteDownloadProgress(id, state, error) {
+            if (state === 3)
+                searchQuery.model.setInstalled(id, true);
+            if (root.detailRow && root.detailRow.itemId === id) {
+                root.detailState = state;
+                if (state === 3)
+                    root.detailRow.installed = true;
+            }
+            if (state === 5 && error.length > 0)
+                W.Action.toast(qsTr("Download failed: ") + error);
+        }
+    }
+
+    function reloadAll() {
+        searchQuery.tags = m_filter_dialog.collect();
+        searchQuery.reload();
+    }
+
+    Connections {
+        target: W.Notify
+        function onDaemonReady() {
+            root.reloadAll();
+        }
+    }
+
+    Component.onCompleted: {
+        if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready)
+            reloadAll();
+    }
+
+    contentItem: RowLayout {
+        spacing: 12
+
+        MD.Pane {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            radius: root.MD.MProp.page.backgroundRadius
+            padding: 0
+            showBackground: true
+
+            contentItem: ColumnLayout {
+                spacing: 0
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 16
+                    Layout.rightMargin: 16
+                    Layout.topMargin: 4
+                    spacing: 8
+
+                    MD.EmbedChip {
+                        id: sortChip
+                        text: root.sortOptions[root.sortIndex].name
+                        trailingIconName: MD.Token.icon.arrow_drop_down
+                        mdState.borderWidth: 1
+                        onClicked: sortMenu.open()
+
+                        MD.Menu {
+                            id: sortMenu
+                            parent: sortChip
+                            y: parent.height
+                            model: root.sortOptions
+                            contentDelegate: MD.MenuItem {
+                                required property var modelData
+                                required property int index
+                                text: modelData.name
+                                icon.name: index === root.sortIndex ? MD.Token.icon.check : ' '
+                                onClicked: {
+                                    root.pickSort(index);
+                                    sortMenu.close();
+                                }
+                            }
+                        }
+                    }
+
+                    W.SearchChip {
+                        id: m_search_field
+                        Layout.preferredWidth: 120
+                        placeholderText: qsTr("Search")
+                        onTextEdited: searchQuery.query = text
+                    }
+
+                    MD.ActionToolBar {
+                        Layout.fillWidth: true
+                        actions: [
+                            MD.Action {
+                                icon.name: MD.Token.icon.filter_list
+                                text: 'Filters'
+                                checked: searchQuery.tags.length > 0
+                                onTriggered: m_filter_dialog.open()
+                            },
+                            MD.Action {
+                                icon.name: MD.Token.icon.refresh
+                                text: 'Refresh'
+                                enabled: !searchQuery.querying
+                                onTriggered: searchQuery.reload()
+                            }
+                        ]
+                    }
+                }
+
+                MD.LinearIndicator {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 16
+                    Layout.rightMargin: 16
+                    visible: searchQuery.querying && searchQuery.model.count > 0
+                    running: visible
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    MD.VerticalGridView {
+                        id: m_grid
+                        anchors.fill: parent
+                        clip: true
+                        cacheBuffer: 300
+                        displayMarginBeginning: 300
+                        displayMarginEnd: 300
+                        currentIndex: -1
+                        topMargin: 2
+                        bottomMargin: 8
+                        leftMargin: 8
+                        rightMargin: 8
+                        visible: count > 0
+
+                        readonly property int _cols: Math.max(1, Math.floor(width / 162))
+                        cellWidth: (width - leftMargin - rightMargin) / _cols
+                        cellHeight: cellWidth
+
+                        model: searchQuery.model
+
+                        delegate: RemoteCard {
+                            onClicked: {
+                                m_grid.currentIndex = index;
+                                root.selectItem(index);
+                            }
+                        }
+
+                        highlightFollowsCurrentItem: true
+                        highlight: Component {
+                            Item {
+                                visible: m_grid.currentItem !== null
+                                z: 2
+                                Rectangle {
+                                    anchors.fill: parent
+                                    anchors.margins: 4
+                                    color: "transparent"
+                                    border.color: MD.Token.color.primary
+                                    border.width: 3
+                                    radius: MD.Token.shape.corner.small + 2
+                                }
+                            }
+                        }
+
+                        onContentYChanged: {
+                            if (searchQuery.hasMore && !searchQuery.querying
+                                && contentY + height >= contentHeight - cellHeight * 2)
+                                searchQuery.loadMore();
+                        }
+                    }
+
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        visible: m_grid.count === 0
+                        spacing: 8
+
+                        MD.BusyIndicator {
+                            Layout.alignment: Qt.AlignHCenter
+                            running: searchQuery.querying
+                            visible: running
+                        }
+
+                        MD.Label {
+                            Layout.alignment: Qt.AlignHCenter
+                            visible: !searchQuery.querying
+                            text: qsTr("No wallpapers found")
+                            typescale: MD.Token.typescale.body_large
+                            color: MD.Token.color.on_surface_variant
+                        }
+                    }
+                }
+            }
+        }
+
+        MD.Pane {
+            Layout.preferredWidth: 300
+            Layout.maximumWidth: 300
+            Layout.fillHeight: true
+            visible: root.detailRow !== null
+            radius: root.MD.MProp.page.backgroundRadius
+            padding: 0
+            showBackground: true
+
+            contentItem: ColumnLayout {
+                spacing: 12
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: 8
+                    Layout.leftMargin: 8
+                    Layout.rightMargin: 8
+                    Item { Layout.fillWidth: true }
+                    MD.IconButton {
+                        action: MD.Action {
+                            icon.name: MD.Token.icon.close
+                            onTriggered: { root.detailRow = null; m_grid.currentIndex = -1; }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 16
+                    Layout.rightMargin: 16
+                    Layout.preferredHeight: width * 0.56
+                    radius: MD.Token.shape.corner.medium
+                    clip: true
+                    color: MD.Token.color.surface_container
+
+                    AnimatedImage {
+                        anchors.fill: parent
+                        source: root.detailRow ? root.detailRow.previewUrl : ""
+                        fillMode: Image.PreserveAspectCrop
+                        cache: true
+                        playing: true
+                        sourceSize.width: 640
+                        sourceSize.height: 640
+                    }
+                }
+
+                Flickable {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.leftMargin: 16
+                    Layout.rightMargin: 16
+                    clip: true
+                    contentWidth: width
+                    contentHeight: m_info.implicitHeight
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    ColumnLayout {
+                        id: m_info
+                        width: parent.width
+                        spacing: 8
+
+                        MD.Label {
+                            Layout.fillWidth: true
+                            text: root.detailRow ? root.detailRow.title : ""
+                            typescale: MD.Token.typescale.title_medium
+                            wrapMode: Text.WordWrap
+                        }
+
+                        MD.Label {
+                            Layout.fillWidth: true
+                            text: root.detailRow ? qsTr("by ") + root.detailRow.author : ""
+                            visible: root.detailRow && root.detailRow.author.length > 0
+                            typescale: MD.Token.typescale.body_medium
+                            color: MD.Token.color.on_surface_variant
+                            wrapMode: Text.WordWrap
+                        }
+
+                        MD.Text {
+                            Layout.topMargin: 4
+                            visible: detailsQuery.size.length > 0
+                            text: "Size"
+                            typescale: MD.Token.typescale.label_medium
+                            color: MD.Token.color.on_surface_variant
+                        }
+                        MD.Text {
+                            visible: detailsQuery.size.length > 0
+                            text: root.fmtSize(detailsQuery.size)
+                            typescale: MD.Token.typescale.body_medium
+                            color: MD.Token.color.on_surface
+                        }
+
+                        Flow {
+                            Layout.fillWidth: true
+                            Layout.topMargin: 4
+                            spacing: 4
+                            visible: detailsQuery.tags.length > 0
+
+                            Repeater {
+                                model: detailsQuery.tags
+                                delegate: MD.AssistChip {
+                                    required property string modelData
+                                    text: modelData
+                                }
+                            }
+                        }
+
+                        MD.Divider {
+                            Layout.fillWidth: true
+                            Layout.topMargin: 4
+                            visible: detailsQuery.description.length > 0 || detailsQuery.querying
+                        }
+
+                        MD.Text {
+                            visible: detailsQuery.description.length > 0 || detailsQuery.querying
+                            text: "Description"
+                            typescale: MD.Token.typescale.label_large
+                            color: MD.Token.color.on_surface_variant
+                        }
+                        MD.Label {
+                            Layout.fillWidth: true
+                            text: detailsQuery.querying ? qsTr("Loading…") : detailsQuery.description
+                            visible: text.length > 0
+                            typescale: MD.Token.typescale.body_medium
+                            color: MD.Token.color.on_surface
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+                }
+
+                MD.Button {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 16
+                    Layout.rightMargin: 16
+                    Layout.bottomMargin: 16
+                    mdState.type: root.detailState === 3 ? MD.Enum.BtFilledTonal : MD.Enum.BtFilled
+                    enabled: root.detailState === 0 || root.detailState === 3
+                    text: {
+                        switch (root.detailState) {
+                        case 1: return qsTr("Pending");
+                        case 2: return qsTr("Downloading");
+                        case 3: return qsTr("Uninstall");
+                        case 4: return qsTr("Retry");
+                        case 5: return qsTr("Retry");
+                        default: return qsTr("Download");
+                        }
+                    }
+                    onClicked: {
+                        if (!root.detailRow) return;
+                        if (root.detailState === 3) {
+                            dlQuery.uninstall(root.detailRow.itemId);
+                        } else {
+                            root.detailState = 1;
+                            dlQuery.start(root.detailRow.itemId);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/qml/page/RemoteCard.qml
+++ b/ui/qml/page/RemoteCard.qml
@@ -1,0 +1,98 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import Qcm.Material as MD
+
+Item {
+    id: root
+
+    required property int index
+    required property string itemId
+    required property string title
+    required property string previewUrl
+    required property string author
+    required property bool installed
+
+    signal clicked()
+
+    width: GridView.view ? GridView.view.cellWidth : 0
+    height: GridView.view ? GridView.view.cellHeight : 0
+
+    readonly property int _radius: MD.Token.shape.corner.extra_small
+
+    Item {
+        id: m_cell
+        anchors.fill: parent
+        anchors.margins: 6
+
+        AnimatedImage {
+            id: m_thumb
+            anchors.fill: parent
+            source: root.previewUrl
+            fillMode: Image.PreserveAspectCrop
+            cache: true
+            playing: true
+            asynchronous: true
+            sourceSize.width: 320
+            sourceSize.height: 320
+            onStatusChanged: if (status === AnimatedImage.Ready) playing = true
+            layer.enabled: true
+            layer.effect: MD.RoundClip {
+                corners: MD.Util.corners(root._radius)
+                size: Qt.vector2d(m_thumb.width, m_thumb.height)
+            }
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: Math.max(0, parent.height - m_title.y)
+            visible: height > 0
+            radius: root._radius
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: "transparent" }
+                GradientStop { position: 1.0; color: Qt.rgba(0, 0, 0, 0.65) }
+            }
+        }
+
+        MD.Text {
+            id: m_title
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: 6
+            text: root.title.length > 0 ? root.title : qsTr("Untitled")
+            typescale: MD.Token.typescale.title_small
+            color: "white"
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            elide: Text.ElideRight
+            maximumLineCount: 2
+            leftPadding: 8
+            rightPadding: 8
+        }
+
+        Rectangle {
+            visible: root.installed
+            anchors { top: parent.top; right: parent.right; margins: 6 }
+            width: m_badge.implicitWidth + 12
+            height: m_badge.implicitHeight + 6
+            radius: height / 2
+            color: MD.Token.color.primary
+
+            MD.Label {
+                id: m_badge
+                anchors.centerIn: parent
+                text: qsTr("Installed")
+                typescale: MD.Token.typescale.label_small
+                color: MD.Token.color.on_primary
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.clicked()
+        }
+    }
+}

--- a/ui/src/mod.cppm
+++ b/ui/src/mod.cppm
@@ -13,6 +13,7 @@ export import :renderer;
 export import :msg.store;
 export import :model.store_item;
 export import :model.list_models;
+export import :model.remote;
 export import :model.filter_rule;
 export import :model.user_property;
 export import :query;

--- a/ui/src/model/remote_model.cpp
+++ b/ui/src/model/remote_model.cpp
@@ -1,0 +1,86 @@
+module;
+#include "waywallen/model/remote_model.moc.h"
+
+module waywallen;
+import :model.remote;
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace waywallen::model
+{
+
+RemoteListModel::RemoteListModel(QObject* parent): QAbstractListModel(parent) {}
+
+int RemoteListModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return static_cast<int>(m_rows.size());
+}
+
+QVariant RemoteListModel::data(const QModelIndex& index, int role) const {
+    if (! index.isValid() || index.row() < 0 || index.row() >= m_rows.size())
+        return {};
+    const auto& r = m_rows.at(index.row());
+    switch (role) {
+    case ItemIdRole: return r.id;
+    case TitleRole: return r.title;
+    case PreviewUrlRole: return r.previewUrl;
+    case AuthorRole: return r.author;
+    case InstalledRole: return r.installed;
+    default: return {};
+    }
+}
+
+QHash<int, QByteArray> RemoteListModel::roleNames() const {
+    return {
+        { ItemIdRole, "itemId"_ba },
+        { TitleRole, "title"_ba },
+        { PreviewUrlRole, "previewUrl"_ba },
+        { AuthorRole, "author"_ba },
+        { InstalledRole, "installed"_ba },
+    };
+}
+
+void RemoteListModel::reset(QList<RemoteRow> rows) {
+    beginResetModel();
+    m_rows = std::move(rows);
+    endResetModel();
+    Q_EMIT countChanged();
+}
+
+void RemoteListModel::append(const QList<RemoteRow>& rows) {
+    if (rows.isEmpty()) return;
+    const int first = static_cast<int>(m_rows.size());
+    beginInsertRows(QModelIndex(), first, first + static_cast<int>(rows.size()) - 1);
+    m_rows.append(rows);
+    endInsertRows();
+    Q_EMIT countChanged();
+}
+
+void RemoteListModel::setInstalled(const QString& id, bool installed) {
+    for (int i = 0; i < m_rows.size(); ++i) {
+        if (m_rows.at(i).id == id) {
+            if (m_rows[i].installed != installed) {
+                m_rows[i].installed = installed;
+                const auto idx = index(i, 0);
+                Q_EMIT dataChanged(idx, idx);
+            }
+            return;
+        }
+    }
+}
+
+QVariantMap RemoteListModel::get(int row) const {
+    QVariantMap m;
+    if (row < 0 || row >= m_rows.size()) return m;
+    const auto& r = m_rows.at(row);
+    m["itemId"_L1] = r.id;
+    m["title"_L1] = r.title;
+    m["previewUrl"_L1] = r.previewUrl;
+    m["author"_L1] = r.author;
+    m["installed"_L1] = r.installed;
+    return m;
+}
+
+}
+
+#include "waywallen/model/remote_model.moc.cpp"

--- a/ui/src/model/remote_model.cppm
+++ b/ui/src/model/remote_model.cppm
@@ -1,0 +1,58 @@
+module;
+#include "QExtra/macro_qt.hpp"
+#include <QtCore/QAbstractListModel>
+
+#ifdef Q_MOC_RUN
+#    include "waywallen/model/remote_model.moc"
+#endif
+
+export module waywallen:model.remote;
+export import qextra;
+
+namespace waywallen::model
+{
+
+export struct RemoteRow {
+    QString id;
+    QString title;
+    QString previewUrl;
+    QString author;
+    bool    installed { false };
+};
+
+export class RemoteListModel : public QAbstractListModel {
+    Q_OBJECT
+    QML_ANONYMOUS
+
+    Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
+
+public:
+    enum Role {
+        ItemIdRole = Qt::UserRole + 1,
+        TitleRole,
+        PreviewUrlRole,
+        AuthorRole,
+        InstalledRole,
+    };
+
+    explicit RemoteListModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    auto count() const -> int { return static_cast<int>(m_rows.size()); }
+
+    void reset(QList<RemoteRow> rows);
+    void append(const QList<RemoteRow>& rows);
+    Q_INVOKABLE void setInstalled(const QString& id, bool installed);
+
+    Q_INVOKABLE QVariantMap get(int row) const;
+
+    Q_SIGNAL void countChanged();
+
+private:
+    QList<RemoteRow> m_rows;
+};
+
+}

--- a/ui/src/notify.cpp
+++ b/ui/src/notify.cpp
@@ -80,6 +80,11 @@ Notify::Notify(QObject* parent): QObject(parent) {
                                                    f.clientProtocolVersion(),
                                                    f.errorCode(),
                                                    f.reason());
+                } else if (evt.hasRemoteDownloadProgress()) {
+                    const auto& p = evt.remoteDownloadProgress();
+                    Q_EMIT remoteDownloadProgress(p.id_proto(),
+                                                    static_cast<int>(p.state()),
+                                                    p.error());
                 }
             },
             Qt::QueuedConnection);

--- a/ui/src/notify.cppm
+++ b/ui/src/notify.cppm
@@ -99,6 +99,7 @@ Q_SIGNALS:
                                  quint32        clientProtocolVersion,
                                  quint32        errorCode,
                                  const QString& reason);
+    void remoteDownloadProgress(const QString& id, int state, const QString& error);
 
 private:
     bool        m_scan_in_progress { false };

--- a/ui/src/proto.cppm
+++ b/ui/src/proto.cppm
@@ -69,6 +69,21 @@ using proto::DisplayLayoutSetResponse;
 using proto::DisplayRenameRequest;
 using proto::DisplayRenameResponse;
 
+using proto::RemoteAvailabilityRequest;
+using proto::RemoteAvailabilityResponse;
+using proto::RemoteItem;
+using proto::RemoteSearchRequest;
+using proto::RemoteSearchResponse;
+using proto::RemoteSortGadget::RemoteSort;
+using proto::RemoteDownloadRequest;
+using proto::RemoteDownloadResponse;
+using proto::RemoteDownloadProgress;
+using proto::RemoteDownloadStateGadget::RemoteDownloadState;
+using proto::RemoteUninstallRequest;
+using proto::RemoteUninstallResponse;
+using proto::RemoteDetailsRequest;
+using proto::RemoteDetailsResponse;
+
 using proto::GpuInfo;
 using proto::GpuListRequest;
 using proto::GpuListResponse;

--- a/ui/src/query/mod.cppm
+++ b/ui/src/query/mod.cppm
@@ -10,3 +10,4 @@ export import :query.health;
 export import :query.display;
 export import :query.gpu;
 export import :query.settings;
+export import :query.remote;

--- a/ui/src/query/remote_query.cpp
+++ b/ui/src/query/remote_query.cpp
@@ -1,0 +1,245 @@
+module;
+#include "waywallen/query/remote_query.moc.h"
+#undef assert
+#include <rstd/macro.hpp>
+
+module waywallen;
+import :query.remote;
+import :app;
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace proto = waywallen::control::v1;
+using namespace qextra::prelude;
+
+namespace waywallen
+{
+
+RemoteAvailabilityQuery::RemoteAvailabilityQuery(QObject* parent): Query(parent) {}
+
+auto RemoteAvailabilityQuery::owned() const -> bool { return m_owned; }
+auto RemoteAvailabilityQuery::contentDir() const -> const QString& { return m_content_dir; }
+
+void RemoteAvailabilityQuery::reload() {
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    auto req = proto::Request {};
+    req.setRemoteAvailability(proto::RemoteAvailabilityRequest {});
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(self->get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [self](const proto::Response& rsp) {
+            const auto& av    = rsp.remoteAvailability();
+            self->m_owned       = av.owned();
+            self->m_content_dir = av.contentDir();
+            Q_EMIT self->ownedChanged();
+        });
+        co_return;
+    });
+}
+
+RemoteSearchQuery::RemoteSearchQuery(QObject* parent)
+    : Query(parent), m_model(new model::RemoteListModel(this)) {
+    connect_requet_reload(&RemoteSearchQuery::queryChanged, this);
+    connect_requet_reload(&RemoteSearchQuery::sortChanged, this);
+    connect_requet_reload(&RemoteSearchQuery::tagsChanged, this);
+}
+
+auto RemoteSearchQuery::query() const -> const QString& { return m_query; }
+void RemoteSearchQuery::setQuery(const QString& v) {
+    if (m_query != v) {
+        m_query = v;
+        Q_EMIT queryChanged();
+    }
+}
+
+auto RemoteSearchQuery::sort() const -> int { return m_sort; }
+void RemoteSearchQuery::setSort(int v) {
+    if (m_sort != v) {
+        m_sort = v;
+        Q_EMIT sortChanged();
+    }
+}
+
+auto RemoteSearchQuery::tags() const -> const QStringList& { return m_tags; }
+void RemoteSearchQuery::setTags(const QStringList& v) {
+    if (m_tags != v) {
+        m_tags = v;
+        Q_EMIT tagsChanged();
+    }
+}
+
+auto RemoteSearchQuery::model() const -> model::RemoteListModel* { return m_model; }
+auto RemoteSearchQuery::hasMore() const -> bool { return m_has_more; }
+auto RemoteSearchQuery::errorText() const -> const QString& { return m_error; }
+
+void RemoteSearchQuery::reload() {
+    m_page = 1;
+    fetchPage(1, false);
+}
+
+void RemoteSearchQuery::loadMore() {
+    if (! m_has_more || querying()) return;
+    fetchPage(m_page + 1, true);
+}
+
+void RemoteSearchQuery::fetchPage(quint32 page, bool append) {
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    auto req   = proto::Request {};
+    auto inner = proto::RemoteSearchRequest {};
+    inner.setQuery(m_query);
+    inner.setSort(static_cast<proto::RemoteSort>(m_sort));
+    inner.setPage(page);
+    inner.setRequiredTags(m_tags);
+    req.setRemoteSearch(std::move(inner));
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req), page, append]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(self->get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [self, page, append](const proto::Response& rsp) {
+            const auto& sr = rsp.remoteSearch();
+            QList<model::RemoteRow> rows;
+            rows.reserve(sr.items().size());
+            for (const auto& it : sr.items()) {
+                rows.push_back(model::RemoteRow {
+                    it.id_proto(),
+                    it.title(),
+                    it.previewUrl(),
+                    it.author(),
+                    it.installed(),
+                });
+            }
+            if (append)
+                self->m_model->append(rows);
+            else
+                self->m_model->reset(std::move(rows));
+            self->m_page     = page;
+            self->m_has_more = sr.hasMore();
+            self->m_error    = sr.error();
+            Q_EMIT self->stateChanged();
+        });
+        co_return;
+    });
+}
+
+RemoteDetailsQuery::RemoteDetailsQuery(QObject* parent): Query(parent) {
+    connect_requet_reload(&RemoteDetailsQuery::itemIdChanged, this);
+}
+
+auto RemoteDetailsQuery::itemId() const -> const QString& { return m_item_id; }
+void RemoteDetailsQuery::setItemId(const QString& v) {
+    if (m_item_id != v) {
+        m_item_id = v;
+        Q_EMIT itemIdChanged();
+    }
+}
+auto RemoteDetailsQuery::description() const -> const QString& { return m_description; }
+auto RemoteDetailsQuery::size() const -> const QString& { return m_size; }
+auto RemoteDetailsQuery::tags() const -> const QStringList& { return m_tags; }
+
+void RemoteDetailsQuery::reload() {
+    m_description.clear();
+    m_size.clear();
+    m_tags.clear();
+    Q_EMIT loaded();
+    if (m_item_id.isEmpty()) return;
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    auto req   = proto::Request {};
+    auto inner = proto::RemoteDetailsRequest {};
+    inner.setId_proto(m_item_id);
+    req.setRemoteDetails(std::move(inner));
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(self->get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [self](const proto::Response& rsp) {
+            const auto& dr = rsp.remoteDetails();
+            self->m_description = dr.description();
+            self->m_size        = dr.size();
+            self->m_tags.clear();
+            for (const auto& t : dr.tags())
+                self->m_tags.push_back(t);
+            Q_EMIT self->loaded();
+        });
+        co_return;
+    });
+}
+
+RemoteDownloadQuery::RemoteDownloadQuery(QObject* parent): Query(parent) {}
+
+void RemoteDownloadQuery::reload() {}
+
+void RemoteDownloadQuery::start(const QString& id) {
+    if (id.isEmpty()) return;
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    auto req   = proto::Request {};
+    auto inner = proto::RemoteDownloadRequest {};
+    inner.setId_proto(id);
+    req.setRemoteDownload(std::move(inner));
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req), id]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(self->get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [self, id](const proto::Response& rsp) {
+            const auto& dr = rsp.remoteDownload();
+            if (dr.accepted()) {
+                Q_EMIT self->accepted(id);
+            } else {
+                Q_EMIT self->rejected(id, dr.error());
+            }
+        });
+        co_return;
+    });
+}
+
+void RemoteDownloadQuery::uninstall(const QString& id) {
+    if (id.isEmpty()) return;
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    auto req   = proto::Request {};
+    auto inner = proto::RemoteUninstallRequest {};
+    inner.setId_proto(id);
+    req.setRemoteUninstall(std::move(inner));
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req), id]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(self->get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [self, id](const proto::Response& rsp) {
+            const auto& ur = rsp.remoteUninstall();
+            if (ur.removed()) {
+                Q_EMIT self->uninstalled(id);
+            } else {
+                Q_EMIT self->uninstallFailed(id, ur.error());
+            }
+        });
+        co_return;
+    });
+}
+
+}
+
+#include "waywallen/query/remote_query.moc.cpp"

--- a/ui/src/query/remote_query.cppm
+++ b/ui/src/query/remote_query.cppm
@@ -1,0 +1,139 @@
+module;
+#include "QExtra/macro_qt.hpp"
+
+#ifdef Q_MOC_RUN
+#    include "waywallen/query/remote_query.moc"
+#endif
+
+export module waywallen:query.remote;
+export import :query.query;
+export import :model.remote;
+
+namespace waywallen
+{
+
+export class RemoteAvailabilityQuery
+    : public Query,
+      public QueryExtra<control::v1::Response, RemoteAvailabilityQuery> {
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(bool owned READ owned NOTIFY ownedChanged FINAL)
+    Q_PROPERTY(QString contentDir READ contentDir NOTIFY ownedChanged FINAL)
+
+public:
+    RemoteAvailabilityQuery(QObject* parent = nullptr);
+
+    auto owned() const -> bool;
+    auto contentDir() const -> const QString&;
+
+    void reload() override;
+
+    Q_SIGNAL void ownedChanged();
+
+private:
+    bool    m_owned { false };
+    QString m_content_dir;
+};
+
+export class RemoteSearchQuery
+    : public Query,
+      public QueryExtra<control::v1::Response, RemoteSearchQuery> {
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QString query READ query WRITE setQuery NOTIFY queryChanged FINAL)
+    Q_PROPERTY(int sort READ sort WRITE setSort NOTIFY sortChanged FINAL)
+    Q_PROPERTY(QStringList tags READ tags WRITE setTags NOTIFY tagsChanged FINAL)
+    Q_PROPERTY(waywallen::model::RemoteListModel* model READ model CONSTANT FINAL)
+    Q_PROPERTY(bool hasMore READ hasMore NOTIFY stateChanged FINAL)
+    Q_PROPERTY(QString errorText READ errorText NOTIFY stateChanged FINAL)
+
+public:
+    RemoteSearchQuery(QObject* parent = nullptr);
+
+    auto query() const -> const QString&;
+    void setQuery(const QString&);
+
+    auto sort() const -> int;
+    void setSort(int);
+
+    auto tags() const -> const QStringList&;
+    void setTags(const QStringList&);
+
+    auto model() const -> model::RemoteListModel*;
+    auto hasMore() const -> bool;
+    auto errorText() const -> const QString&;
+
+    void reload() override;
+    Q_INVOKABLE void loadMore();
+
+    Q_SIGNAL void queryChanged();
+    Q_SIGNAL void sortChanged();
+    Q_SIGNAL void tagsChanged();
+    Q_SIGNAL void stateChanged();
+
+private:
+    void fetchPage(quint32 page, bool append);
+
+    QString                    m_query;
+    int                        m_sort { 0 };
+    QStringList                m_tags;
+    model::RemoteListModel*  m_model;
+    bool                       m_has_more { false };
+    QString                    m_error;
+    quint32                    m_page { 1 };
+};
+
+export class RemoteDetailsQuery
+    : public Query,
+      public QueryExtra<control::v1::Response, RemoteDetailsQuery> {
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QString itemId READ itemId WRITE setItemId NOTIFY itemIdChanged FINAL)
+    Q_PROPERTY(QString description READ description NOTIFY loaded FINAL)
+    Q_PROPERTY(QString size READ size NOTIFY loaded FINAL)
+    Q_PROPERTY(QStringList tags READ tags NOTIFY loaded FINAL)
+
+public:
+    RemoteDetailsQuery(QObject* parent = nullptr);
+
+    auto itemId() const -> const QString&;
+    void setItemId(const QString&);
+    auto description() const -> const QString&;
+    auto size() const -> const QString&;
+    auto tags() const -> const QStringList&;
+
+    void reload() override;
+
+    Q_SIGNAL void itemIdChanged();
+    Q_SIGNAL void loaded();
+
+private:
+    QString     m_item_id;
+    QString     m_description;
+    QString     m_size;
+    QStringList m_tags;
+};
+
+export class RemoteDownloadQuery
+    : public Query,
+      public QueryExtra<control::v1::Response, RemoteDownloadQuery> {
+    Q_OBJECT
+    QML_ELEMENT
+
+public:
+    RemoteDownloadQuery(QObject* parent = nullptr);
+
+    void reload() override;
+    Q_INVOKABLE void start(const QString& id);
+    Q_INVOKABLE void uninstall(const QString& id);
+
+    Q_SIGNAL void accepted(const QString& id);
+    Q_SIGNAL void rejected(const QString& id, const QString& error);
+    Q_SIGNAL void uninstalled(const QString& id);
+    Q_SIGNAL void uninstallFailed(const QString& id, const QString& error);
+};
+
+}


### PR DESCRIPTION
Adds a Discover tab to browse and download Wallpaper Engine wallpapers from the Steam Workshop without leaving the app. It only shows up if you actually own Wallpaper Engine, detected automatically from the local Steam install.

What it does:
- Search, sort (Trending / Recent / Popular) and filter by the usual Workshop tags — type, genre, resolution and so on. Mature content is off by default and gated behind an 18+ confirmation.
- Pick a wallpaper to see its preview, description, size and tags on the side, then download or uninstall it.
- Downloads go through the Steam client, so no Steam credentials are handled here.
- Requests to Steam are throttled and cached to stay well under its rate limits.

Layout and behaviour follow the existing Wallpapers page as closely as I could.

For this project I made some use of AI to get a hand with a few concepts, code and explanations of some messages.

All testing was done on my own PC, if you run into issues let me know with a comment here, or on Discord [Burlone](https://discord.com/users/1065395762298630214) / [B-Burlone413](https://discord.com/users/155906800611360769).