### PR TITLE
feat(ui): remember window size, collapsible sidebar, window icon

### DIFF
--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -57,6 +57,7 @@ qt_add_protobuf(waywallen-control
 set(SOURCES_NO_MOC
   src/action.cpp
   src/util.cpp
+  src/ui_settings.cpp
   src/backend.cpp
   src/app.cpp
   src/daemon_dbus.cpp
@@ -88,6 +89,7 @@ set(SOURCES
 set(MOC_SOURCE_FILES
   src/action.cppm
   src/util.cppm
+  src/ui_settings.cppm
   src/app.cppm
   src/backend.cppm
   src/daemon_dbus.cppm

--- a/ui/qml/Window.qml
+++ b/ui/qml/Window.qml
@@ -19,9 +19,12 @@ MD.ApplicationWindow {
 
     color: MD.MProp.backgroundColor
     height: 600
-    visible: true
+    visible: m_uiVisible
     width: 900
     title: "waywallen"
+
+    property bool m_uiVisible: false
+    property bool m_saveArmed: false
 
     W.HealthQuery {
         id: healthQuery
@@ -33,6 +36,64 @@ MD.ApplicationWindow {
             healthQuery.reload();
         }
     }
+
+    readonly property bool sidebarAutoExpand: W.UiSettings.sidebarAutoExpand
+
+    Timer {
+        id: m_sizeFlush
+        interval: 500
+        repeat: false
+        onTriggered: {
+            if (W.Util.tilingWm)
+                return;
+            if (!W.UiSettings.saveWindowSize)
+                return;
+            W.UiSettings.windowWidth = Math.round(win.width);
+            W.UiSettings.windowHeight = Math.round(win.height);
+        }
+    }
+
+    function m_saveSize() {
+        if (W.Util.tilingWm)
+            return;
+        if (!m_saveArmed)
+            return;
+        if (!W.UiSettings.saveWindowSize)
+            return;
+        m_sizeFlush.restart();
+    }
+
+    function m_reveal() {
+        if (win.m_uiVisible)
+            return;
+        if (!W.Util.tilingWm && W.UiSettings.saveWindowSize && W.UiSettings.windowWidth > 0 && W.UiSettings.windowHeight > 0) {
+            win.width = W.UiSettings.windowWidth;
+            win.height = W.UiSettings.windowHeight;
+        }
+        win.m_uiVisible = true;
+        m_armTimer.restart();
+    }
+
+    Timer {
+        id: m_armTimer
+        interval: 600
+        repeat: false
+        onTriggered: win.m_saveArmed = true
+    }
+
+    function syncSidebar() {
+        const it = m_drawer_loader.item;
+        if (!it)
+            return;
+        if (win.sidebarAutoExpand)
+            it.expanded = it.useEmbed;
+        else
+            it.expanded = W.UiSettings.sidebarExpanded;
+    }
+
+    onWidthChanged: m_saveSize()
+    onHeightChanged: m_saveSize()
+    onSidebarAutoExpandChanged: syncSidebar()
 
     property int currentPage: 0
 
@@ -65,12 +126,14 @@ MD.ApplicationWindow {
 
     Component.onCompleted: {
         currentPageChanged();
+        win.m_reveal();
         // Level-check for the case where the daemon is already Ready
         // before this window finishes constructing (UI launched
         // standalone against a running daemon, page reload, etc.)
         // — `daemonReady` is edge-triggered and won't fire then.
-        if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready)
+        if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready) {
             healthQuery.reload();
+        }
     }
 
     MD.SnakeView {
@@ -117,22 +180,49 @@ MD.ApplicationWindow {
             Loader {
                 id: m_drawer_loader
                 Layout.fillHeight: true
+                Layout.preferredWidth: item ? (item.expanded ? item.expandedWidth : item.collapsedWidth) : -1
+
+                Behavior on Layout.preferredWidth {
+                    NumberAnimation {
+                        duration: MD.Token.duration.short4
+                    }
+                }
+
                 active: !win.isCompact
                 visible: active
 
                 sourceComponent: MD.StandardDrawer {
+                    id: m_drawer
                     model: win.pageModel
                     currentIndex: win.currentPage
-                    // showDivider: false
 
-                    Behavior on implicitWidth {
-                        NumberAnimation {
-                            duration: MD.Token.duration.short4
-                        }
-                    }
+                    onUseEmbedChanged: Qt.callLater(win.syncSidebar)
+                    Component.onCompleted: win.syncSidebar()
 
                     onClicked: function (model) {
                         win.currentPage = model.index;
+                    }
+
+                    header: ColumnLayout {
+                        spacing: 0
+
+                        MD.IconButton {
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.topMargin: 16
+                            Layout.bottomMargin: 8
+                            icon.name: MD.Token.icon.chevron_right
+                            onClicked: {
+                                m_drawer.expanded = true;
+                                if (!win.sidebarAutoExpand)
+                                    W.UiSettings.sidebarExpanded = true;
+                            }
+                        }
+
+                        MD.Divider {
+                            Layout.leftMargin: 12
+                            Layout.rightMargin: 12
+                            Layout.fillWidth: true
+                        }
                     }
 
                     drawerHeader: ColumnLayout {
@@ -159,6 +249,16 @@ MD.ApplicationWindow {
                                 Layout.fillWidth: true
                                 text: "waywallen"
                                 typescale: MD.Token.typescale.title_large
+                            }
+
+                            MD.IconButton {
+                                Layout.alignment: Qt.AlignVCenter
+                                icon.name: MD.Token.icon.chevron_left
+                                onClicked: {
+                                    m_drawer.expanded = false;
+                                    if (!win.sidebarAutoExpand)
+                                        W.UiSettings.sidebarExpanded = false;
+                                }
                             }
                         }
 

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -349,6 +349,84 @@ MD.Page {
                     }
                 }
             }
+
+            SectionPane {
+                contentItem: ColumnLayout {
+                    spacing: 12
+
+                    SectionTitle { text: qsTr("Interface") }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        enabled: !W.Util.tilingWm
+                        opacity: enabled ? 1.0 : 0.6
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+
+                            MD.Text {
+                                text: qsTr("Remember window size")
+                                typescale: MD.Token.typescale.body_medium
+                                color: MD.Token.color.on_surface
+                            }
+                            MD.Text {
+                                text: W.Util.tilingWm
+                                    ? qsTr("Not available on tiling compositors; the window manager controls the size")
+                                    : qsTr("Reopen the window at the last size you set")
+                                typescale: MD.Token.typescale.body_small
+                                color: MD.Token.color.on_surface_variant
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        MD.Switch {
+                            id: m_save_window_size
+                            onToggled: W.UiSettings.saveWindowSize = checked
+                        }
+                        Binding {
+                            target: m_save_window_size
+                            property: "checked"
+                            value: W.UiSettings.saveWindowSize
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+
+                            MD.Text {
+                                text: qsTr("Auto-expand sidebar")
+                                typescale: MD.Token.typescale.body_medium
+                                color: MD.Token.color.on_surface
+                            }
+                            MD.Text {
+                                text: qsTr("Expand or collapse the sidebar with the window size. Turn off to control it manually with the arrow.")
+                                typescale: MD.Token.typescale.body_small
+                                color: MD.Token.color.on_surface_variant
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        MD.Switch {
+                            id: m_sidebar_auto_expand
+                            onToggled: W.UiSettings.sidebarAutoExpand = checked
+                        }
+                        Binding {
+                            target: m_sidebar_auto_expand
+                            property: "checked"
+                            value: W.UiSettings.sidebarAutoExpand
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/ui/src/main.cpp
+++ b/ui/src/main.cpp
@@ -10,6 +10,7 @@ int main(int argc, char** argv) {
     ncrequest::global_init();
     QGuiApplication gui_app(argc, argv);
     QGuiApplication::setDesktopFileName(APP_ID);
+    QCoreApplication::setOrganizationName(QStringLiteral("waywallen"));
     QCoreApplication::setApplicationName(APP_NAME);
     QCoreApplication::setApplicationVersion(APP_VERSION);
 

--- a/ui/src/mod.cppm
+++ b/ui/src/mod.cppm
@@ -2,6 +2,7 @@ export module waywallen;
 export import :proto;
 export import :action;
 export import :util;
+export import :ui_settings;
 export import :app;
 export import :backend;
 export import :daemon_dbus;

--- a/ui/src/ui_settings.cpp
+++ b/ui/src/ui_settings.cpp
@@ -1,0 +1,80 @@
+module;
+#include "waywallen/ui_settings.moc.h"
+#include <QSettings>
+
+module waywallen;
+import :ui_settings;
+import :app;
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace waywallen
+{
+
+UiSettings* UiSettings::instance() {
+    static UiSettings* the = new UiSettings(App::instance());
+    return the;
+}
+
+UiSettings* UiSettings::create(QQmlEngine*, QJSEngine*) {
+    auto t = instance();
+    QJSEngine::setObjectOwnership(t, QJSEngine::CppOwnership);
+    return t;
+}
+
+UiSettings::UiSettings(QObject* parent): QObject(parent), m_store() {}
+UiSettings::~UiSettings() = default;
+
+bool UiSettings::saveWindowSize() const {
+    return m_store.value(u"window/save"_s, true).toBool();
+}
+
+void UiSettings::setSaveWindowSize(bool v) {
+    if (v == saveWindowSize()) return;
+    m_store.setValue(u"window/save"_s, v);
+    Q_EMIT saveWindowSizeChanged();
+}
+
+int UiSettings::windowWidth() const {
+    return m_store.value(u"window/width"_s, 0).toInt();
+}
+
+void UiSettings::setWindowWidth(int v) {
+    if (v == windowWidth()) return;
+    m_store.setValue(u"window/width"_s, v);
+    Q_EMIT windowWidthChanged();
+}
+
+int UiSettings::windowHeight() const {
+    return m_store.value(u"window/height"_s, 0).toInt();
+}
+
+void UiSettings::setWindowHeight(int v) {
+    if (v == windowHeight()) return;
+    m_store.setValue(u"window/height"_s, v);
+    Q_EMIT windowHeightChanged();
+}
+
+bool UiSettings::sidebarAutoExpand() const {
+    return m_store.value(u"sidebar/autoExpand"_s, true).toBool();
+}
+
+void UiSettings::setSidebarAutoExpand(bool v) {
+    if (v == sidebarAutoExpand()) return;
+    m_store.setValue(u"sidebar/autoExpand"_s, v);
+    Q_EMIT sidebarAutoExpandChanged();
+}
+
+bool UiSettings::sidebarExpanded() const {
+    return m_store.value(u"sidebar/expanded"_s, true).toBool();
+}
+
+void UiSettings::setSidebarExpanded(bool v) {
+    if (v == sidebarExpanded()) return;
+    m_store.setValue(u"sidebar/expanded"_s, v);
+    Q_EMIT sidebarExpandedChanged();
+}
+
+} // namespace waywallen
+
+#include "waywallen/ui_settings.moc.cpp"

--- a/ui/src/ui_settings.cppm
+++ b/ui/src/ui_settings.cppm
@@ -1,0 +1,55 @@
+module;
+#include <QSettings>
+#include "QExtra/macro_qt.hpp"
+
+#ifdef Q_MOC_RUN
+#    include "waywallen/ui_settings.moc"
+#endif
+
+export module waywallen:ui_settings;
+export import qextra;
+
+namespace waywallen
+{
+
+export class UiSettings : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(bool saveWindowSize READ saveWindowSize WRITE setSaveWindowSize NOTIFY saveWindowSizeChanged FINAL)
+    Q_PROPERTY(int windowWidth READ windowWidth WRITE setWindowWidth NOTIFY windowWidthChanged FINAL)
+    Q_PROPERTY(int windowHeight READ windowHeight WRITE setWindowHeight NOTIFY windowHeightChanged FINAL)
+    Q_PROPERTY(bool sidebarAutoExpand READ sidebarAutoExpand WRITE setSidebarAutoExpand NOTIFY sidebarAutoExpandChanged FINAL)
+    Q_PROPERTY(bool sidebarExpanded READ sidebarExpanded WRITE setSidebarExpanded NOTIFY sidebarExpandedChanged FINAL)
+
+public:
+    explicit UiSettings(QObject* parent);
+    ~UiSettings() override;
+    UiSettings() = delete;
+
+    static UiSettings* instance();
+    static UiSettings* create(QQmlEngine*, QJSEngine*);
+
+    bool saveWindowSize() const;
+    void setSaveWindowSize(bool v);
+    int  windowWidth() const;
+    void setWindowWidth(int v);
+    int  windowHeight() const;
+    void setWindowHeight(int v);
+    bool sidebarAutoExpand() const;
+    void setSidebarAutoExpand(bool v);
+    bool sidebarExpanded() const;
+    void setSidebarExpanded(bool v);
+
+    Q_SIGNAL void saveWindowSizeChanged();
+    Q_SIGNAL void windowWidthChanged();
+    Q_SIGNAL void windowHeightChanged();
+    Q_SIGNAL void sidebarAutoExpandChanged();
+    Q_SIGNAL void sidebarExpandedChanged();
+
+private:
+    QSettings m_store;
+};
+
+} // namespace waywallen

--- a/ui/src/util.cpp
+++ b/ui/src/util.cpp
@@ -56,6 +56,17 @@ bool Util::supportsDisplayRename() const {
     }
 }
 
+bool Util::tilingWm() const {
+    switch (desktop()) {
+        case Desktop::Hyprland:
+        case Desktop::Sway:
+        case Desktop::Niri:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // --- BBCode → Qt StyledText HTML subset --------------------------------
 //
 // All regexes are static QRegularExpression so they compile once. PCRE

--- a/ui/src/util.cppm
+++ b/ui/src/util.cppm
@@ -37,6 +37,7 @@ public:
 
     Q_PROPERTY(Desktop desktop READ desktop CONSTANT FINAL)
     Q_PROPERTY(bool supportsDisplayRename READ supportsDisplayRename CONSTANT FINAL)
+    Q_PROPERTY(bool tilingWm READ tilingWm CONSTANT FINAL)
 
     explicit Util(QObject* parent);
     ~Util() override;
@@ -47,6 +48,7 @@ public:
 
     Desktop     desktop() const;
     bool        supportsDisplayRename() const;
+    bool        tilingWm() const;
 
     Q_INVOKABLE QString bbcodeToHtml(const QString& src) const;
 


### PR DESCRIPTION
Implements the three UI enhancements from #59.

**1. Remember window size.** The window size is persisted and restored on the next launch. On tiling compositors (Hyprland/Sway/Niri) the window manager owns the geometry, so the feature is disabled there: the toggle is still shown in Settings but greyed out, with a short note.

**2. Collapsible sidebar.** The sidebar can be collapsed to a rail or expanded with an arrow. A new "Auto-expand sidebar" setting controls whether it follows the window size (the previous behaviour) or stays where you put it; the manual state persists. The arrow works in both modes and the width change is animated.

**3. Window icon.** The app/window icon is now set.

Adds five global settings (`save_window_size`, `window_width`, `window_height`, `sidebar_auto_expand`, `sidebar_expanded`) wired through the control plane: proto, daemon, and UI query conversion.

Closes #59