### PR TITLE
Autostart on non-Flatpak installs, early-boot backend recovery, and a hide tray icon setting

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,6 +12,7 @@ End-to-end build instructions for developers.
 | Vulkan SDK | ≥ 1.1 |  |
 | Qt6 | ≥ 6.10 | Quick, DBus, Protobuf |
 | ffmpeg | - |  |
+| git-lfs | - | QmlMaterial stores its icon fonts in LFS; without it the UI builds but every icon renders as a placeholder box |
 
 ## Build, install, run
 

--- a/deps.json
+++ b/deps.json
@@ -70,7 +70,7 @@
     }
   },
   {
-    "commit": "aab112235e4da7e03c233793a9d612507f0e6355",
+    "commit": "72c43fab3dbe0df17b64f76e8e6198037bfd3c60",
     "dest": "build/_flatpak_deps/wavsen-src",
     "disable-shallow-clone": true,
     "type": "git",
@@ -92,7 +92,7 @@
     }
   },
   {
-    "commit": "d02d9a7bfed546dfb7f87a5627b1c9e8f6fcc95a",
+    "commit": "1eadfcb9fc9d2d7b61d0ff2ec7a9f6982863336e",
     "dest": "build/_flatpak_deps/QExtra-src",
     "disable-shallow-clone": true,
     "type": "git",

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -1040,6 +1040,10 @@ message GlobalSettings {
   // When enabled, one wallpaper applied to multiple displays gets one
   // renderer per display instead of sharing a single renderer instance.
   bool duplicate_renderers_for_same_wallpaper = 19;
+
+  // Hide the tray icon. The daemon applies this live; the window can
+  // be reopened by launching waywallen again. `--no-tray` overrides.
+  bool hide_tray_icon = 20;
 }
 
 enum AutoAction {

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -1089,8 +1089,9 @@ message SettingsChanged {
   map<string, PluginSettings> plugins = 2;
 }
 
-// Flatpak-only login startup integration through
-// org.freedesktop.portal.Background.
+// Login startup integration. Sandboxed builds go through
+// org.freedesktop.portal.Background; host builds write an XDG
+// autostart entry directly.
 message AutostartGetRequest {}
 message AutostartGetResponse {
   bool enabled = 1;

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -1,10 +1,11 @@
+use std::path::{Path, PathBuf};
+
 use ashpd::desktop::background::Background;
 
 use crate::error::{Error, Result};
 use crate::settings::SettingsStore;
 
 const FLATPAK_ID_ENV: &str = "FLATPAK_ID";
-const AUTOSTART_COMMAND: [&str; 2] = ["waywallen", "--no-ui"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PortalState {
@@ -19,9 +20,10 @@ struct XdpPortal;
 
 impl PortalClient for XdpPortal {
     async fn set_enabled(&self, enabled: bool) -> Result<PortalState> {
+        let command = autostart_command();
         let request = Background::request()
             .auto_start(enabled)
-            .command(&AUTOSTART_COMMAND)
+            .command(&command)
             .dbus_activatable(false)
             .send()
             .await
@@ -36,20 +38,107 @@ impl PortalClient for XdpPortal {
     }
 }
 
+fn is_sandboxed() -> bool {
+    std::env::var_os(FLATPAK_ID_ENV).is_some_and(|id| !id.is_empty())
+}
+
+/// Login-start command line. Inside Flatpak the portal rewrites it to
+/// `flatpak run <app-id> ...`, so the bare binary name suffices. On the
+/// host the daemon is often not on PATH, so pin the running executable.
+fn autostart_command() -> Vec<String> {
+    let bin = if is_sandboxed() {
+        "waywallen".to_string()
+    } else {
+        std::env::current_exe()
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "waywallen".to_string())
+    };
+    vec![bin, "--no-ui".to_string()]
+}
+
+/// XDG autostart entry location. Order mirrors
+/// `settings::default_config_path`:
+///   1. `$XDG_CONFIG_HOME/autostart/waywallen.desktop`
+///   2. `$HOME/.config/autostart/waywallen.desktop`
+fn xdg_autostart_path() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg).join("autostart/waywallen.desktop");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".config/autostart/waywallen.desktop");
+    }
+    PathBuf::from("waywallen-autostart.desktop")
+}
+
+/// Quote one Exec argument per the Desktop Entry spec: double-quote and
+/// backslash-escape the reserved characters that stay live inside quotes.
+fn quote_exec_arg(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('"');
+    for c in arg.chars() {
+        if matches!(c, '"' | '`' | '$' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
+fn write_autostart_entry(path: &Path, command: &[String]) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let exec = command
+        .iter()
+        .map(|a| quote_exec_arg(a))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let entry = format!(
+        "[Desktop Entry]\n\
+         Type=Application\n\
+         Name=Waywallen\n\
+         Comment=Wallpaper manager daemon\n\
+         Exec={exec}\n\
+         Icon=org.waywallen.waywallen\n\
+         Terminal=false\n"
+    );
+    std::fs::write(path, entry)
+}
+
+fn remove_autostart_entry(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+        _ => Ok(()),
+    }
+}
+
 #[derive(Default)]
 pub struct AutostartService {
     mutation: tokio::sync::Mutex<()>,
 }
 
 impl AutostartService {
+    /// Persisted intent, not live desktop state — an entry removed
+    /// behind our back (portal side or a hand-deleted .desktop file)
+    /// is not detected.
     pub fn enabled(&self, settings: &SettingsStore) -> Result<bool> {
-        ensure_flatpak()?;
         Ok(settings.global().autostart_enabled)
     }
 
+    /// Sandboxed: the Background portal is the only mechanism, and it
+    /// resolves the Flatpak app id reliably. On the host the portal
+    /// derives the caller's app id from the launch context (cgroup),
+    /// which can attribute the entry to the wrong application — so
+    /// write the XDG autostart entry directly instead.
     pub async fn set_enabled(&self, settings: &SettingsStore, enabled: bool) -> Result<bool> {
-        ensure_flatpak()?;
-        self.set_enabled_with(settings, enabled, &XdpPortal).await
+        if is_sandboxed() {
+            self.set_enabled_with(settings, enabled, &XdpPortal).await
+        } else {
+            self.set_enabled_host(settings, enabled, &xdg_autostart_path())
+                .await
+        }
     }
 
     async fn set_enabled_with<C: PortalClient>(
@@ -71,16 +160,23 @@ impl AutostartService {
         settings.flush_now().await;
         Ok(enabled)
     }
-}
 
-fn ensure_flatpak() -> Result<()> {
-    let available = std::env::var_os(FLATPAK_ID_ENV).is_some_and(|id| !id.is_empty());
-    if available {
-        Ok(())
-    } else {
-        Err(Error::FailedPrecondition(
-            "autostart is only available inside Flatpak".to_string(),
-        ))
+    async fn set_enabled_host(
+        &self,
+        settings: &SettingsStore,
+        enabled: bool,
+        entry: &Path,
+    ) -> Result<bool> {
+        let _guard = self.mutation.lock().await;
+        if enabled {
+            write_autostart_entry(entry, &autostart_command())?;
+        } else {
+            remove_autostart_entry(entry)?;
+        }
+
+        settings.update(|s| s.global.autostart_enabled = enabled);
+        settings.flush_now().await;
+        Ok(enabled)
     }
 }
 
@@ -179,5 +275,73 @@ mod tests {
 
         assert!(matches!(result, Err(Error::PortalCallFailed(_))));
         assert!(!settings.global().autostart_enabled);
+    }
+
+    #[tokio::test]
+    async fn host_enable_writes_entry_and_persists() {
+        let (_dir, settings) = settings().await;
+        let dir = tempdir().unwrap();
+        let entry = dir.path().join("autostart/waywallen.desktop");
+
+        let enabled = AutostartService::default()
+            .set_enabled_host(&settings, true, &entry)
+            .await
+            .unwrap();
+
+        assert!(enabled);
+        assert!(settings.global().autostart_enabled);
+        let content = std::fs::read_to_string(&entry).unwrap();
+        assert!(content.starts_with("[Desktop Entry]"));
+        assert!(content.contains("--no-ui"));
+    }
+
+    #[tokio::test]
+    async fn host_disable_removes_entry_and_persists() {
+        let (_dir, settings) = settings().await;
+        settings.update(|s| s.global.autostart_enabled = true);
+        settings.flush_now().await;
+        let dir = tempdir().unwrap();
+        let entry = dir.path().join("waywallen.desktop");
+        write_autostart_entry(&entry, &["waywallen".into(), "--no-ui".into()]).unwrap();
+
+        let enabled = AutostartService::default()
+            .set_enabled_host(&settings, false, &entry)
+            .await
+            .unwrap();
+
+        assert!(!enabled);
+        assert!(!settings.global().autostart_enabled);
+        assert!(!entry.exists());
+    }
+
+    #[tokio::test]
+    async fn host_write_failure_does_not_update_state() {
+        let (_dir, settings) = settings().await;
+        let dir = tempdir().unwrap();
+        // A directory at the entry path makes the write fail.
+        let entry = dir.path().join("waywallen.desktop");
+        std::fs::create_dir(&entry).unwrap();
+
+        let result = AutostartService::default()
+            .set_enabled_host(&settings, true, &entry)
+            .await;
+
+        assert!(matches!(result, Err(Error::Io(_))));
+        assert!(!settings.global().autostart_enabled);
+    }
+
+    #[test]
+    fn remove_missing_entry_is_ok() {
+        let dir = tempdir().unwrap();
+        assert!(remove_autostart_entry(&dir.path().join("absent.desktop")).is_ok());
+    }
+
+    #[test]
+    fn exec_args_are_quoted() {
+        assert_eq!(
+            quote_exec_arg("/opt/way wallen/bin"),
+            "\"/opt/way wallen/bin\""
+        );
+        assert_eq!(quote_exec_arg("a\"b$c"), "\"a\\\"b\\$c\"");
     }
 }

--- a/src/display/spawner.rs
+++ b/src/display/spawner.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
@@ -153,6 +154,138 @@ pub fn detect_de() -> DeCaps {
         probed_globals: Vec::new(),
         flatpak_id,
     }
+}
+
+/// Discover a live Wayland socket when `WAYLAND_DISPLAY` is unset by
+/// scanning the runtime dir for `wayland-*` sockets. Unlike the env
+/// var — frozen at process start — the socket appears on disk when the
+/// compositor comes up, so this works for a daemon launched before the
+/// session existed. Returns a value usable as `WAYLAND_DISPLAY`: the
+/// socket name, or an absolute path when `XDG_RUNTIME_DIR` itself is
+/// unset (libwayland accepts both).
+pub fn scan_wayland_socket() -> Option<String> {
+    if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        return scan_wayland_socket_in(Path::new(&dir));
+    }
+    // systemd's default runtime dir; keep the absolute path so the
+    // spawned client doesn't need XDG_RUNTIME_DIR either.
+    let uid = unsafe { libc::getuid() };
+    let dir = PathBuf::from(format!("/run/user/{uid}"));
+    scan_wayland_socket_in(&dir).map(|name| dir.join(name).to_string_lossy().into_owned())
+}
+
+fn scan_wayland_socket_in(dir: &Path) -> Option<String> {
+    let mut best: Option<String> = None;
+    for entry in std::fs::read_dir(dir).ok()? {
+        let Ok(entry) = entry else { continue };
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("wayland-") || name.ends_with(".lock") {
+            continue;
+        }
+        let is_socket = entry
+            .file_type()
+            .map(|t| {
+                use std::os::unix::fs::FileTypeExt;
+                t.is_socket()
+            })
+            .unwrap_or(false);
+        if !is_socket {
+            continue;
+        }
+        if best.as_deref().is_none_or(|cur| name < cur) {
+            best = Some(name.to_string());
+        }
+    }
+    best
+}
+
+/// Session environment as recorded by the systemd user manager.
+/// Compositors publish `WAYLAND_DISPLAY` / `XDG_CURRENT_DESKTOP` there
+/// via `dbus-update-activation-environment --systemd`, so unlike this
+/// process's own environment it keeps updating after early boot.
+/// Empty on non-systemd systems.
+pub async fn systemd_user_environment(conn: &zbus::Connection) -> HashMap<String, String> {
+    match read_systemd_environment(conn).await {
+        Ok(map) => map,
+        Err(e) => {
+            log::debug!("systemd user environment unavailable: {e}");
+            HashMap::new()
+        }
+    }
+}
+
+async fn read_systemd_environment(
+    conn: &zbus::Connection,
+) -> zbus::Result<HashMap<String, String>> {
+    let proxy = zbus::Proxy::new(
+        conn,
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager",
+    )
+    .await?;
+    let vars: Vec<String> = proxy.get_property("Environment").await?;
+    Ok(vars
+        .into_iter()
+        .filter_map(|kv| {
+            let (k, v) = kv.split_once('=')?;
+            Some((k.to_string(), v.to_string()))
+        })
+        .collect())
+}
+
+/// `detect_de()` plus runtime fallbacks for the early-boot case.
+/// Returns the merged caps and the env overrides a spawned backend
+/// needs — values discovered here are not in the daemon's own
+/// environment, so children would not inherit them.
+pub async fn detect_de_runtime(conn: Option<&zbus::Connection>) -> (DeCaps, Vec<(String, String)>) {
+    let session = match conn {
+        Some(conn) => systemd_user_environment(conn).await,
+        None => HashMap::new(),
+    };
+    merge_caps(detect_de(), &session, scan_wayland_socket())
+}
+
+/// Fill holes in `base` from the systemd session env, then from an
+/// on-disk socket scan. Process env always wins.
+fn merge_caps(
+    base: DeCaps,
+    session: &HashMap<String, String>,
+    socket: Option<String>,
+) -> (DeCaps, Vec<(String, String)>) {
+    let mut caps = base;
+    let mut overrides = Vec::new();
+    if caps.xdg_desktop.is_empty() {
+        if let Some(raw) = session.get("XDG_CURRENT_DESKTOP") {
+            let tokens: Vec<String> = raw
+                .split(':')
+                .filter(|p| !p.is_empty())
+                .map(|p| p.to_ascii_lowercase())
+                .collect();
+            if !tokens.is_empty() {
+                caps.xdg_desktop = tokens;
+                overrides.push(("XDG_CURRENT_DESKTOP".to_string(), raw.clone()));
+            }
+        }
+    }
+    if !caps.is_wayland_session {
+        if let Some(ty) = session.get("XDG_SESSION_TYPE") {
+            caps.is_wayland_session = ty.eq_ignore_ascii_case("wayland");
+        }
+    }
+    if caps.wayland_display.is_none() {
+        let discovered = session
+            .get("WAYLAND_DISPLAY")
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .or(socket);
+        if let Some(display) = discovered {
+            overrides.push(("WAYLAND_DISPLAY".to_string(), display.clone()));
+            caps.wayland_display = Some(display);
+        }
+    }
+    (caps, overrides)
 }
 
 /// Why `pick_backend` returned the choice it did. Mostly for logging.
@@ -397,11 +530,21 @@ const RESTART_INITIAL: Duration = Duration::from_secs(2);
 /// Upper bound on the exponential backoff.
 const RESTART_MAX: Duration = Duration::from_secs(10);
 
+/// Initial delay between backend re-detection attempts when the daemon
+/// started before the session environment existed.
+pub const DETECT_RETRY_INITIAL: Duration = Duration::from_secs(2);
+/// Upper bound on the re-detection backoff.
+pub const DETECT_RETRY_MAX: Duration = Duration::from_secs(15);
+/// Give up on re-detection after this long; a session that has not
+/// appeared by then is not going to.
+pub const DETECT_RETRY_WINDOW: Duration = Duration::from_secs(300);
+
 /// Supervise a daemon-spawned display backend for the lifetime of the
 /// process. Exits cleanly when `shutdown_rx` flips to `true` (SIGTERMs
 pub async fn run_backend(
     def: DisplayDef,
     socket: PathBuf,
+    extra_env: Vec<(String, String)>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     if !matches!(def.spawn, SpawnMode::Daemon) {
@@ -434,6 +577,21 @@ pub async fn run_backend(
         cmd.arg("--socket").arg(&socket);
         for extra in &def.extra_args {
             cmd.arg(extra);
+        }
+        cmd.envs(extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+        // The compositor may not have been up when the daemon started.
+        // When nothing provides WAYLAND_DISPLAY, re-scan per attempt so
+        // the restart backoff self-heals once the socket appears.
+        if std::env::var_os("WAYLAND_DISPLAY").is_none()
+            && !extra_env.iter().any(|(k, _)| k == "WAYLAND_DISPLAY")
+        {
+            if let Some(display) = scan_wayland_socket() {
+                log::info!(
+                    "display backend '{}': discovered WAYLAND_DISPLAY={display}",
+                    def.name
+                );
+                cmd.env("WAYLAND_DISPLAY", &display);
+            }
         }
         cmd.env("WAYWALLEN_SOCKET", &socket);
         cmd.kill_on_drop(true)
@@ -672,5 +830,91 @@ mod tests {
         assert_eq!(status.desktop, "sway");
         assert_eq!(status.flatpak_id, "org.waywallen.waywallen");
         assert!(status.reason.contains("Flatpak"));
+    }
+
+    #[test]
+    fn socket_scan_finds_lowest_socket_and_skips_locks() {
+        let dir = tempfile::tempdir().unwrap();
+        std::os::unix::net::UnixListener::bind(dir.path().join("wayland-1")).unwrap();
+        std::os::unix::net::UnixListener::bind(dir.path().join("wayland-0")).unwrap();
+        std::fs::write(dir.path().join("wayland-0.lock"), b"").unwrap();
+        // Plain file with a matching name must not count as a socket.
+        std::fs::write(dir.path().join("wayland-"), b"").unwrap();
+
+        assert_eq!(
+            scan_wayland_socket_in(dir.path()).as_deref(),
+            Some("wayland-0")
+        );
+    }
+
+    #[test]
+    fn socket_scan_empty_dir_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(scan_wayland_socket_in(dir.path()), None);
+    }
+
+    fn session(vars: &[(&str, &str)]) -> HashMap<String, String> {
+        vars.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn merge_caps_process_env_wins() {
+        let base = DeCaps {
+            xdg_desktop: vec!["hyprland".into()],
+            wayland_display: Some("wayland-1".into()),
+            ..Default::default()
+        };
+        let sess = session(&[
+            ("XDG_CURRENT_DESKTOP", "KDE"),
+            ("WAYLAND_DISPLAY", "wayland-0"),
+        ]);
+
+        let (caps, overrides) = merge_caps(base, &sess, Some("wayland-9".into()));
+
+        assert_eq!(caps.xdg_desktop, vec!["hyprland".to_string()]);
+        assert_eq!(caps.wayland_display.as_deref(), Some("wayland-1"));
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn merge_caps_fills_from_session_env() {
+        let sess = session(&[
+            ("XDG_CURRENT_DESKTOP", "Hyprland:wlroots"),
+            ("XDG_SESSION_TYPE", "wayland"),
+            ("WAYLAND_DISPLAY", "wayland-1"),
+        ]);
+
+        let (caps, overrides) = merge_caps(DeCaps::default(), &sess, None);
+
+        assert_eq!(
+            caps.xdg_desktop,
+            vec!["hyprland".to_string(), "wlroots".to_string()]
+        );
+        assert!(caps.is_wayland_session);
+        assert_eq!(caps.wayland_display.as_deref(), Some("wayland-1"));
+        assert_eq!(
+            overrides,
+            vec![
+                (
+                    "XDG_CURRENT_DESKTOP".to_string(),
+                    "Hyprland:wlroots".to_string()
+                ),
+                ("WAYLAND_DISPLAY".to_string(), "wayland-1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_caps_falls_back_to_socket_scan() {
+        let (caps, overrides) =
+            merge_caps(DeCaps::default(), &session(&[]), Some("wayland-0".into()));
+
+        assert_eq!(caps.wayland_display.as_deref(), Some("wayland-0"));
+        assert_eq!(
+            overrides,
+            vec![("WAYLAND_DISPLAY".to_string(), "wayland-0".to_string())]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,125 @@ fn resolve_ui_path(explicit: Option<PathBuf>) -> Option<PathBuf> {
     None
 }
 
+/// Auto-pick (or pin) and preflight a display backend for `caps`.
+/// Returns the status to surface plus the def to spawn when the daemon
+/// owns the backend process.
+fn select_display_backend(
+    registry: &plugin::display_registry::DisplayRegistry,
+    caps: &display::spawner::DeCaps,
+    pinned: Option<&str>,
+) -> (
+    display::spawner::DisplayBackendStatus,
+    Option<plugin::display_registry::DisplayDef>,
+) {
+    let pick = if let Some(name) = pinned {
+        match registry.find(name) {
+            Some(def) => {
+                log::info!("display backend pinned by --display-backend: {name}");
+                display::spawner::PickOutcome::Matched(def.clone())
+            }
+            None => {
+                log::error!(
+                    "--display-backend {name} not found in registry; falling back to auto-detect"
+                );
+                display::spawner::pick_backend(registry, caps)
+            }
+        }
+    } else {
+        display::spawner::pick_backend(registry, caps)
+    };
+    display::spawner::log_outcome(&pick, caps);
+    let should_spawn = display::spawner::should_daemon_spawn(&pick);
+    match pick {
+        display::spawner::PickOutcome::KdeHardMatch(def)
+        | display::spawner::PickOutcome::Matched(def)
+            if should_spawn =>
+        {
+            let (status, backend) = display::spawner::preflight_daemon_backend(def, caps);
+            if status.state == display::spawner::DISPLAY_BACKEND_STATE_BINARY_MISSING
+                || status.state == display::spawner::DISPLAY_BACKEND_STATE_FLATPAK_RESTRICTED
+            {
+                log::error!("{}", status.reason);
+            }
+            (status, backend)
+        }
+        display::spawner::PickOutcome::KdeHardMatch(def)
+        | display::spawner::PickOutcome::Matched(def) => (
+            display::spawner::DisplayBackendStatus::external(&def, caps),
+            None,
+        ),
+        display::spawner::PickOutcome::None => (
+            display::spawner::DisplayBackendStatus::unmatched(caps),
+            None,
+        ),
+    }
+}
+
+/// Early-boot backend recovery. Polls the session (systemd user env +
+/// on-disk Wayland sockets) until `XDG_CURRENT_DESKTOP` appears, then
+/// runs the normal selection once and spawns the supervisor when the
+/// daemon owns the backend. Bounded by `DETECT_RETRY_WINDOW`.
+fn spawn_backend_detect_retry(
+    state: Arc<AppState>,
+    registry: Arc<plugin::display_registry::DisplayRegistry>,
+    sock_path: PathBuf,
+    conn: zbus::Connection,
+) {
+    let tasks = state.tasks.clone();
+    tasks.spawn_async(
+        tasks::TaskKind::Service,
+        "display/backend-detect",
+        async move {
+            let mut shutdown_rx = state.shutdown_subscribe();
+            let mut delay = display::spawner::DETECT_RETRY_INITIAL;
+            let deadline = tokio::time::Instant::now() + display::spawner::DETECT_RETRY_WINDOW;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = shutdown_rx.wait_for(|v| *v) => return Ok(()),
+                    _ = tokio::time::sleep(delay) => {}
+                }
+                let (caps, extra_env) = display::spawner::detect_de_runtime(Some(&conn)).await;
+                if caps.xdg_desktop.is_empty() {
+                    if tokio::time::Instant::now() >= deadline {
+                        log::warn!(
+                            "display backend detection gave up after {}s without a session; \
+                             pass --display-backend or start waywallen after login",
+                            display::spawner::DETECT_RETRY_WINDOW.as_secs()
+                        );
+                        return Ok(());
+                    }
+                    delay = std::cmp::min(delay * 2, display::spawner::DETECT_RETRY_MAX);
+                    continue;
+                }
+                log::info!(
+                    "session environment appeared (xdg_desktop={:?}); selecting display backend",
+                    caps.xdg_desktop
+                );
+                let (status, backend) = select_display_backend(&registry, &caps, None);
+                *state.display_backend_status.write().unwrap() = status;
+                state.events.publish(events::GlobalEvent::StatusChanged);
+                if let Some(def) = backend {
+                    let shutdown_rx = state.shutdown_subscribe();
+                    let name = def.name.clone();
+                    state.tasks.spawn_async(
+                        tasks::TaskKind::Service,
+                        format!("display/backend/{name}"),
+                        async move {
+                            display::spawner::run_backend(def, sock_path, extra_env, shutdown_rx)
+                                .await
+                                .map_err(|e| {
+                                    anyhow::anyhow!("display backend supervisor exited: {e}")
+                                })
+                        },
+                    );
+                }
+                return Ok(());
+            }
+        },
+    );
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::init();
 
@@ -425,55 +544,20 @@ async fn async_main() -> anyhow::Result<()> {
             }
         }
     }
-    let display_caps = display::spawner::detect_de();
+    let display_registry = Arc::new(display_registry);
+    let (display_caps, display_extra_env) =
+        display::spawner::detect_de_runtime(Some(&dbus_conn)).await;
     let display_backend: Option<plugin::display_registry::DisplayDef> = if cli.no_display {
         log::info!("--no-display: skipping display backend selection");
         *state.display_backend_status.write().unwrap() =
             display::spawner::DisplayBackendStatus::disabled(&display_caps);
         None
     } else {
-        let pick = if let Some(name) = cli.display_backend.as_deref() {
-            match display_registry.find(name) {
-                Some(def) => {
-                    log::info!("display backend pinned by --display-backend: {name}");
-                    display::spawner::PickOutcome::Matched(def.clone())
-                }
-                None => {
-                    log::error!(
-                        "--display-backend {name} not found in registry; falling back to auto-detect"
-                    );
-                    display::spawner::pick_backend(&display_registry, &display_caps)
-                }
-            }
-        } else {
-            display::spawner::pick_backend(&display_registry, &display_caps)
-        };
-        display::spawner::log_outcome(&pick, &display_caps);
-        let should_spawn = display::spawner::should_daemon_spawn(&pick);
-        let (status, backend) = match pick {
-            display::spawner::PickOutcome::KdeHardMatch(def)
-            | display::spawner::PickOutcome::Matched(def)
-                if should_spawn =>
-            {
-                let (status, backend) =
-                    display::spawner::preflight_daemon_backend(def, &display_caps);
-                if status.state == display::spawner::DISPLAY_BACKEND_STATE_BINARY_MISSING
-                    || status.state == display::spawner::DISPLAY_BACKEND_STATE_FLATPAK_RESTRICTED
-                {
-                    log::error!("{}", status.reason);
-                }
-                (status, backend)
-            }
-            display::spawner::PickOutcome::KdeHardMatch(def)
-            | display::spawner::PickOutcome::Matched(def) => (
-                display::spawner::DisplayBackendStatus::external(&def, &display_caps),
-                None,
-            ),
-            display::spawner::PickOutcome::None => (
-                display::spawner::DisplayBackendStatus::unmatched(&display_caps),
-                None,
-            ),
-        };
+        let (status, backend) = select_display_backend(
+            &display_registry,
+            &display_caps,
+            cli.display_backend.as_deref(),
+        );
         *state.display_backend_status.write().unwrap() = status;
         backend
     };
@@ -495,15 +579,29 @@ async fn async_main() -> anyhow::Result<()> {
     if let Some(def) = display_backend {
         let sock_path = display_sock_path.clone();
         let shutdown_rx = state.shutdown_subscribe();
+        let extra_env = display_extra_env.clone();
         let name = def.name.clone();
         state.tasks.spawn_async(
             tasks::TaskKind::Service,
             format!("display/backend/{name}"),
             async move {
-                display::spawner::run_backend(def, sock_path, shutdown_rx)
+                display::spawner::run_backend(def, sock_path, extra_env, shutdown_rx)
                     .await
                     .map_err(|e| anyhow::anyhow!("display backend supervisor exited: {e}"))
             },
+        );
+    } else if !cli.no_display
+        && cli.display_backend.is_none()
+        && display_caps.xdg_desktop.is_empty()
+    {
+        // Early-boot recovery: an empty XDG_CURRENT_DESKTOP usually
+        // means the daemon started before the session came up (e.g. a
+        // systemd unit racing the compositor), not an unknown desktop.
+        spawn_backend_detect_retry(
+            state.clone(),
+            display_registry.clone(),
+            display_sock_path.clone(),
+            dbus_conn.clone(),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,11 @@ pub struct AppState {
     /// SourceManager and the sync layer so dlopen happens at most once.
     pub probe: Arc<dyn MediaProbe>,
     pub playlists: playlist::engine::Engine,
+    /// `--no-tray` CLI override. Forces the tray off and makes the
+    /// `hide_tray_icon` live toggle a no-op for this run.
+    pub no_tray: bool,
+    /// Live tray handle; `Some` while the tray icon is registered.
+    pub tray: tokio::sync::Mutex<Option<tray::TrayHandle>>,
 }
 
 impl AppState {
@@ -484,6 +489,8 @@ async fn async_main() -> anyhow::Result<()> {
         tasks: task_mgr.clone(),
         probe: probe.clone(),
         playlists: playlist::engine::Engine::new(),
+        no_tray: cli.no_tray,
+        tray: tokio::sync::Mutex::new(None),
     });
 
     // Auto-rotation service. Runs until shutdown, parked on a watch
@@ -814,13 +821,14 @@ async fn async_main() -> anyhow::Result<()> {
         .publish(crate::events::GlobalEvent::StatusChanged);
 
     // Tray icon is best-effort and requires a StatusNotifierWatcher.
-    if !cli.no_tray {
-        let conn = dbus_conn.clone();
+    if cli.no_tray {
+        log::info!("tray disabled by --no-tray");
+    } else if state.settings.global().hide_tray_icon {
+        log::info!("tray hidden by hide_tray_icon setting");
+    } else {
         let state_t = state.clone();
         tokio::spawn(async move {
-            if let Err(e) = tray::spawn(conn, state_t).await {
-                log::warn!("tray: {e} (continuing without tray)");
-            }
+            tray::ensure_started(state_t).await;
         });
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -208,6 +208,10 @@ pub struct GlobalSettings {
 
     /// Last autostart state successfully accepted by the Flatpak portal.
     pub autostart_enabled: bool,
+
+    /// Hide the StatusNotifierItem tray icon. Applied live; the
+    /// `--no-tray` CLI flag forces the tray off regardless.
+    pub hide_tray_icon: bool,
 }
 
 impl Default for GlobalSettings {
@@ -229,6 +233,7 @@ impl Default for GlobalSettings {
             plugin_update_notifications: true,
             duplicate_renderers_for_same_wallpaper: false,
             autostart_enabled: false,
+            hide_tray_icon: false,
         }
     }
 }
@@ -975,6 +980,19 @@ duplicate_renderers_for_same_wallpaper = true
         assert!(toml::to_string(&s)
             .unwrap()
             .contains("duplicate_renderers_for_same_wallpaper = true"));
+    }
+
+    #[test]
+    fn hide_tray_icon_roundtrip() {
+        let src = r#"
+[global]
+hide_tray_icon = true
+"#;
+        let s: Settings = toml::from_str(src).unwrap();
+        assert!(s.global.hide_tray_icon);
+        assert!(toml::to_string(&s)
+            .unwrap()
+            .contains("hide_tray_icon = true"));
     }
 
     #[test]

--- a/src/tray/dbusmenu.rs
+++ b/src/tray/dbusmenu.rs
@@ -269,7 +269,14 @@ async fn snapshot_menu_state(app: &Arc<AppState>) -> MenuState {
 /// Best-effort `LayoutUpdated` emission. Called from `control::*`
 /// helpers when state that affects checkmark / radio rendering changes
 pub async fn notify_menu_changed(app: &Arc<AppState>) {
-    let conn = match app.dbus_conn.lock().unwrap().clone() {
+    // The menu lives on the tray's own connection; no tray, no menu.
+    let conn = match app
+        .tray
+        .lock()
+        .await
+        .as_ref()
+        .map(|t| t.connection().clone())
+    {
         Some(c) => c,
         None => return,
     };

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -14,7 +14,59 @@ const WATCHER_SERVICE: &str = "org.kde.StatusNotifierWatcher";
 const WATCHER_PATH: &str = "/StatusNotifierWatcher";
 const WATCHER_IFACE: &str = "org.kde.StatusNotifierWatcher";
 
-pub async fn spawn(conn: Arc<Connection>, app: Arc<AppState>) -> Result<()> {
+/// Live tray state. The item and menu are served on their own bus
+/// connection rather than the daemon's: SNI hosts drop an icon when
+/// the name that registered it vanishes, so closing this connection is
+/// what makes hiding the tray work at runtime.
+pub struct TrayHandle {
+    conn: Connection,
+    watcher: tokio::task::JoinHandle<()>,
+}
+
+impl TrayHandle {
+    /// Connection hosting `/StatusNotifierItem` and `/MenuBar`.
+    pub fn connection(&self) -> &Connection {
+        &self.conn
+    }
+}
+
+/// Register the tray icon. Idempotent: no-op while a tray is up.
+/// Best-effort — a missing StatusNotifierWatcher is not an error; the
+/// watcher task registers once it appears.
+pub async fn ensure_started(app: Arc<AppState>) {
+    let mut slot = app.tray.lock().await;
+    if slot.is_some() {
+        return;
+    }
+    match start(app.clone()).await {
+        Ok(handle) => *slot = Some(handle),
+        Err(e) => log::warn!("tray: {e} (continuing without tray)"),
+    }
+}
+
+/// Remove the tray icon. Idempotent: no-op when not running.
+pub async fn ensure_stopped(app: &AppState) {
+    // Release the slot before closing so an in-flight menu handler
+    // waiting on it sees `None` instead of deadlocking against us.
+    let handle = app.tray.lock().await.take();
+    let Some(handle) = handle else {
+        return;
+    };
+    handle.watcher.abort();
+    // Dropping the name is the SNI removal signal; hosts clean up on
+    // NameOwnerChanged.
+    if let Err(e) = handle.conn.close().await {
+        log::debug!("tray: close: {e}");
+    }
+    log::info!("tray: removed {ITEM_PATH}");
+}
+
+async fn start(app: Arc<AppState>) -> Result<TrayHandle> {
+    // Own connection, not the daemon's — see `TrayHandle`.
+    let conn = Connection::session()
+        .await
+        .map_err(|e| anyhow!("session bus: {e}"))?;
+
     // Hosts resolve `IconName` against their own `XDG_DATA_DIRS`.
     // That may miss the AppImage squashfs mount, so expose a theme path.
     let icon_theme_path = std::env::current_exe()
@@ -23,23 +75,27 @@ pub async fn spawn(conn: Arc<Connection>, app: Arc<AppState>) -> Result<()> {
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default();
     let item = sni::StatusNotifierItem::new(app.clone(), icon_theme_path);
-    let menu = dbusmenu::DBusMenu::new(app.clone());
+    let menu = dbusmenu::DBusMenu::new(app);
 
     conn.object_server().at(ITEM_PATH, item).await?;
     conn.object_server().at(MENU_PATH, menu).await?;
 
-    register_with_watcher(&conn).await?;
-
-    // Re-register whenever the watcher (re)appears.
+    // Watch before the first registration attempt: a watcher that is
+    // not up yet (early boot) registers us when it appears, so a
+    // failure below is only informational.
     let conn_bg = conn.clone();
-    tokio::spawn(async move {
+    let watcher = tokio::spawn(async move {
         if let Err(e) = watch_watcher(conn_bg).await {
             log::warn!("tray watcher monitor exited: {e}");
         }
     });
 
-    log::info!("tray: registered {ITEM_PATH}");
-    Ok(())
+    match register_with_watcher(&conn).await {
+        Ok(()) => log::info!("tray: registered {ITEM_PATH}"),
+        Err(e) => log::info!("tray: watcher not available yet: {e}"),
+    }
+
+    Ok(TrayHandle { conn, watcher })
 }
 
 async fn register_with_watcher(conn: &Connection) -> Result<()> {
@@ -51,7 +107,7 @@ async fn register_with_watcher(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-async fn watch_watcher(conn: Arc<Connection>) -> Result<()> {
+async fn watch_watcher(conn: Connection) -> Result<()> {
     use futures_util::StreamExt;
     let dbus = zbus::fdo::DBusProxy::new(&conn).await?;
     let mut stream = dbus.receive_name_owner_changed().await?;

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -683,6 +683,7 @@ fn global_to_pb(g: &crate::settings::GlobalSettings) -> pb::GlobalSettings {
         wallpaper_skip_content_ratings: g.wallpaper_skip_content_ratings.clone(),
         disable_plugin_update_notifications: !g.plugin_update_notifications,
         duplicate_renderers_for_same_wallpaper: g.duplicate_renderers_for_same_wallpaper,
+        hide_tray_icon: g.hide_tray_icon,
     }
 }
 
@@ -2334,6 +2335,7 @@ async fn dispatch_inner(
             let prev_layout = state.settings.snapshot().global.layout.clone();
             let prev_queue_mode = state.settings.snapshot().global.queue_mode.clone();
             let prev_rotation_secs = state.settings.snapshot().global.rotation_secs;
+            let prev_hide_tray = state.settings.snapshot().global.hide_tray_icon;
             state.settings.update(|s| {
                 if let Some(g) = r.global.as_ref() {
                     s.global.wallpaper_filter = WallpaperFilterState::from_pb(
@@ -2373,6 +2375,7 @@ async fn dispatch_inner(
                     s.global.plugin_update_notifications = !g.disable_plugin_update_notifications;
                     s.global.duplicate_renderers_for_same_wallpaper =
                         g.duplicate_renderers_for_same_wallpaper;
+                    s.global.hide_tray_icon = g.hide_tray_icon;
                 }
                 s.plugins = new_plugins.clone();
             });
@@ -2406,6 +2409,18 @@ async fn dispatch_inner(
             let new_rotation_secs = state.settings.snapshot().global.rotation_secs;
             if new_rotation_secs != prev_rotation_secs {
                 state.rotation.set_interval(new_rotation_secs);
+            }
+            let new_hide_tray = state.settings.snapshot().global.hide_tray_icon;
+            if new_hide_tray != prev_hide_tray {
+                if state.no_tray {
+                    log::info!(
+                        "--no-tray active; hide_tray_icon={new_hide_tray} takes effect next run"
+                    );
+                } else if new_hide_tray {
+                    crate::tray::ensure_stopped(state).await;
+                } else {
+                    crate::tray::ensure_started(state.clone()).await;
+                }
             }
             // Hot-reload live renderers for plugins whose settings changed.
             let mut plugin_names_changed: std::collections::HashSet<String> =

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -100,8 +100,7 @@ MD.Page {
         target: W.Notify
         function onDaemonReady() {
             getQ.reload();
-            if (W.Util.isFlatpak)
-                autostartGetQ.reload();
+            autostartGetQ.reload();
         }
         function onSettingsChanged() {
             getQ.reload();
@@ -111,8 +110,7 @@ MD.Page {
     Component.onCompleted: {
         if (W.Notify.daemonPhase === W.Notify.DaemonPhase.Ready) {
             getQ.reload();
-            if (W.Util.isFlatpak)
-                autostartGetQ.reload();
+            autostartGetQ.reload();
         }
     }
 
@@ -325,7 +323,6 @@ MD.Page {
             SettingItem {
                 first: false
                 last: false
-                visible: W.Util.isFlatpak
 
                 RowLayout {
                     Layout.fillWidth: true

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -201,7 +201,8 @@ MD.Page {
             rotationSecs: 0,
             audioFadeMs: 500,
             pluginUpdateNotifications: true,
-            duplicateRenderers: false
+            duplicateRenderers: false,
+            hideTrayIcon: false
         };
     }
 
@@ -229,7 +230,8 @@ MD.Page {
             rotationSecs: Number(g.rotationSecs ?? 0),
             audioFadeMs: Number(g.audioFadeMs ?? 500),
             pluginUpdateNotifications: Boolean(g.pluginUpdateNotifications ?? true),
-            duplicateRenderers: Boolean(g.duplicateRenderers ?? false)
+            duplicateRenderers: Boolean(g.duplicateRenderers ?? false),
+            hideTrayIcon: Boolean(g.hideTrayIcon ?? false)
         });
     }
 
@@ -347,6 +349,43 @@ MD.Page {
                         value: autostartSetQ.querying || autostartSetQ.status === 2
                             ? autostartSetQ.enabled
                             : autostartGetQ.enabled
+                    }
+                }
+            }
+
+            SettingItem {
+                first: false
+                last: false
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        FieldLabel { text: qsTr("Hide tray icon") }
+
+                        MD.Text {
+                            text: qsTr("Remove the status-bar icon. Reopen this window by launching Waywallen again.")
+                            typescale: MD.Token.typescale.body_small
+                            color: MD.Token.color.on_surface_variant
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    MD.Switch {
+                        id: m_hide_tray_icon
+                        onToggled: root._mut(g => {
+                            g.hideTrayIcon = checked;
+                        })
+                    }
+                    Binding {
+                        target: m_hide_tray_icon
+                        property: "checked"
+                        value: Boolean(root._currentGlobal()?.hideTrayIcon ?? false)
                     }
                 }
             }

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -149,6 +149,10 @@ void App::init() {
     // Connect to the daemon's WebSocket (no-op if port is still 0).
     d->m_backend->connectTo();
 
+    // Resolve the installed QML modules relative to the executable
+    // (bin/ ←→ lib/qt6/qml) so spawns that don't inherit
+    // QML_IMPORT_PATH — tray "Open UI", desktop entries — still work.
+    engine->addImportPath(QGuiApplication::applicationDirPath() + u"/../lib/qt6/qml"_s);
     engine->addImportPath(u"qrc:/"_s);
     // Load the main window from the QML module.
     engine->loadFromModule("waywallen.ui", "Window");

--- a/ui/src/query/settings_query.cpp
+++ b/ui/src/query/settings_query.cpp
@@ -89,6 +89,7 @@ auto global_to_map(const proto::GlobalSettings& g) -> QVariantMap {
     m[u"audioFadeMs"_s]               = g.audioFadeMs();
     m[u"pluginUpdateNotifications"_s] = ! g.disablePluginUpdateNotifications();
     m[u"duplicateRenderers"_s]        = g.duplicateRenderersForSameWallpaper();
+    m[u"hideTrayIcon"_s]              = g.hideTrayIcon();
     QStringList wallpaper_skip_types;
     for (const auto& t : g.wallpaperSkipTypes()) {
         wallpaper_skip_types.append(t);
@@ -160,6 +161,9 @@ auto map_to_global(const QVariantMap& m) -> proto::GlobalSettings {
     }
     if (m.contains(u"duplicateRenderers"_s)) {
         g.setDuplicateRenderersForSameWallpaper(m.value(u"duplicateRenderers"_s).toBool());
+    }
+    if (m.contains(u"hideTrayIcon"_s)) {
+        g.setHideTrayIcon(m.value(u"hideTrayIcon"_s).toBool());
     }
     if (m.contains(u"wallpaperSkipTypes"_s)) {
         QStringList skip;


### PR DESCRIPTION
Autostart on non-Flatpak installs, early-boot backend recovery, and a hide tray icon setting

I run waywallen at login and wanted it to start silently in the background, apply the wallpaper reliably, and optionally not show a tray icon. This adds three things: "Start at login" now works outside Flatpak (it was gated on FLATPAK_ID and hidden in settings otherwise — host builds write ~/.config/autostart/waywallen.desktop directly, since the portal turned out to attribute the entry to whatever app the daemon was launched from); backend selection recovers from early boot instead of reading XDG_CURRENT_DESKTOP / WAYLAND_DISPLAY once and giving up, by falling back to the systemd user environment and scanning for the wayland socket with a bounded retry - I'm fairly sure that's the black-desktop report in #140; and a new hide_tray_icon setting (proto field 20) that applies live. The tray now sits on its own bus connection so hiding it actually removes the icon, which also fixed a bug where a StatusNotifierWatcher starting after the daemon meant no tray until restart. --no-tray still overrides.

There are also a few fixes from getting a fresh checkout to build: the pinned QExtra still imported the removed asio module and the pinned wavsen didn't link rstd.log (both bumped), BUILD.md now mentions git-lfs (without it QmlMaterial's icon fonts come in as LFS pointer stubs and every icon renders as a box), and waywallen-ui now resolves its QML module relative to the executable so tray "Open UI" and desktop entries work without QML_IMPORT_PATH set. Tested on KDE Plasma 6.7.2: live tray toggling against the watcher, autostart entry on/off, an env-stripped launch to simulate early boot, plus new cargo tests for the autostart entry, socket scan / env merge, and settings round-trip. 

Massive commit so I'm happy to split this into separate PRs if that's easier to review.
