### PR TITLE
Lock-screen wallpaper + per-location layout

### DIFF
--- a/proto/control.proto
+++ b/proto/control.proto
@@ -65,6 +65,7 @@ message Request {
     WallpaperPropertySetRequest wallpaper_property_set = 43;
     WallpaperApplyViaPortalRequest wallpaper_apply_via_portal = 44;
     DisplayRenameRequest      display_rename = 45;
+    DisplayLockWallpaperSetRequest display_lock_wallpaper_set = 67;
     PluginInstallRequest      plugin_install = 46;
     PluginListRequest         plugin_list = 47;
     TagListRequest            tag_list = 48;
@@ -135,6 +136,7 @@ message Response {
     WallpaperPropertySetResponse wallpaper_property_set = 43;
     WallpaperApplyViaPortalResponse wallpaper_apply_via_portal = 44;
     DisplayRenameResponse      display_rename = 45;
+    DisplayLockWallpaperSetResponse display_lock_wallpaper_set = 67;
     PluginInstallResponse      plugin_install = 46;
     PluginListResponse         plugin_list = 47;
     TagListResponse            tag_list = 48;
@@ -637,6 +639,8 @@ message DisplayInfo {
   // this value so display settings remain independently editable.
   LayoutPrefs display_layout = 12;
   LayoutSource effective_layout_source = 13;
+  string lock_wallpaper = 14;
+  bool has_lock_screen = 15;
 }
 
 message DisplayRenameRequest {
@@ -651,6 +655,13 @@ message DisplayRenameRequest {
 message DisplayRenameResponse {
   DisplayInfo display = 1;
 }
+
+message DisplayLockWallpaperSetRequest {
+  repeated uint64 display_ids = 1;
+  string wallpaper_id = 2;
+}
+
+message DisplayLockWallpaperSetResponse {}
 
 message RemoteAvailabilityRequest {}
 

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -25,7 +25,8 @@ message ServerFrame {
 }
 
 message Request {
-  reserved 55, 56;
+  reserved 55, 56, 59;
+  reserved "wallpaper_layout_set";
 
   uint64 request_id = 1;
   oneof payload {
@@ -76,7 +77,6 @@ message Request {
     RemoteUninstallRequest    remote_uninstall = 53;
     RemoteDetailsRequest      remote_details = 54;
     PlaylistJumpToRequest     playlist_jump_to = 58;
-    WallpaperLayoutSetRequest wallpaper_layout_set = 59;
     PluginDeleteRequest       plugin_delete = 60;
     WallpaperRemoveRequest    wallpaper_remove = 61;
     PluginInspectRequest      plugin_inspect = 62;
@@ -88,7 +88,8 @@ message Request {
 }
 
 message Response {
-  reserved 55, 56;
+  reserved 55, 56, 59;
+  reserved "wallpaper_layout_set";
 
   uint64 request_id = 1;
   // Coarse status class, kept for back-compat with clients that haven't
@@ -147,7 +148,6 @@ message Response {
     RemoteUninstallResponse    remote_uninstall = 53;
     RemoteDetailsResponse      remote_details = 54;
     Empty                      playlist_jump_to = 58;
-    WallpaperLayoutSetResponse wallpaper_layout_set = 59;
     PluginDeleteResponse       plugin_delete = 60;
     WallpaperRemoveResponse    wallpaper_remove = 61;
     PluginInspectResponse      plugin_inspect = 62;
@@ -370,10 +370,9 @@ message WallpaperEntry {
   // Stable source/plugin identifier (e.g. Wallpaper Engine workshop id).
   // Empty when the source didn't set one.
   string external_id = 15;
-  // Per-wallpaper display layout override. When set, this whole layout
-  // wins over the display's own layout while the wallpaper is active.
-  LayoutPrefs wallpaper_layout_override = 16;
-  bool wallpaper_layout_override_set = 17;
+  // 16, 17 were a per-wallpaper layout override, now replaced by per-display layout.
+  reserved 16, 17;
+  reserved "wallpaper_layout_override", "wallpaper_layout_override_set";
   // True when the source plugin can remove this item from its backing
   // storage. The daemon still owns the DB row deletion after plugin success.
   bool supports_item_remove = 18;
@@ -433,18 +432,6 @@ message WallpaperPropertySetRequest {
   }
 }
 message WallpaperPropertySetResponse {}
-
-// Commit or clear the per-wallpaper display layout override. Unlike
-// `WallpaperPropertySetRequest`, this is daemon-owned data and is
-// persisted outside renderer user-property overrides.
-message WallpaperLayoutSetRequest {
-  string wallpaper_id = 1;
-  bool clear = 2;
-  LayoutPrefs layout = 3;
-}
-message WallpaperLayoutSetResponse {
-  WallpaperEntry entry = 1;
-}
 
 message WallpaperRemoveRequest {
   string wallpaper_id = 1;

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -613,6 +613,12 @@ enum LayoutSource {
   LAYOUT_SOURCE_WALLPAPER = 3;
 }
 
+// Which layout DisplayLayoutSetRequest mutates: desktop or lock screen.
+enum LayoutLocation {
+  LAYOUT_LOCATION_DESKTOP = 0;
+  LAYOUT_LOCATION_LOCK = 1;
+}
+
 message DisplayInfo {
   uint64 display_id  = 1;
   string name        = 2;
@@ -641,6 +647,10 @@ message DisplayInfo {
   LayoutSource effective_layout_source = 13;
   string lock_wallpaper = 14;
   bool has_lock_screen = 15;
+  // Resolved lock-screen layout; the Displays-tab lock section binds here.
+  LayoutPrefs lock_display_layout = 16;
+  // Sparse per-display lock-screen layout override for the edit form.
+  LayoutOverride lock_layout_override = 17;
 }
 
 message DisplayRenameRequest {
@@ -785,6 +795,8 @@ message DisplayLayoutSetRequest {
   bool clear_rotation = 6;
   uint64 display_id   = 7;
   bool clear_location = 8;
+  // Which layout to mutate; defaults to desktop for older clients.
+  LayoutLocation location = 9;
   reserved 5;
   reserved "clear_clear_rgba";
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -926,16 +926,12 @@ async fn apply_shared_renderer(
     spawn_req: renderer_manager::SpawnRequest,
     target: Option<&[DisplayId]>,
     target_ids: &[DisplayId],
-    wallpaper_layout_override: crate::wallpaper::properties::WallpaperLayoutOverride,
     first_frame_timeout: Option<Duration>,
 ) -> Result<String> {
     let renderer_id = match reusable_renderer_for_target(app, &spawn_req, target_ids, false).await {
         Some(existing) => existing,
         None => spawn_renderer_for_target(app, spawn_req, target).await?,
     };
-    app.router
-        .set_renderer_wallpaper_layout_override(&renderer_id, wallpaper_layout_override)
-        .await;
     match target {
         None => app.router.relink_all_displays_to(&renderer_id).await,
         Some(ids) => app.router.relink_displays_to(ids, &renderer_id).await,
@@ -948,7 +944,6 @@ async fn apply_duplicate_renderers(
     app: &Arc<AppState>,
     spawn_req: &renderer_manager::SpawnRequest,
     target_ids: &[DisplayId],
-    wallpaper_layout_override: crate::wallpaper::properties::WallpaperLayoutOverride,
     first_frame_timeout: Option<Duration>,
 ) -> Result<String> {
     let mut first_renderer_id: Option<String> = None;
@@ -958,9 +953,6 @@ async fn apply_duplicate_renderers(
             Some(existing) => existing,
             None => spawn_renderer_for_target(app, spawn_req.clone(), Some(&single)).await?,
         };
-        app.router
-            .set_renderer_wallpaper_layout_override(&renderer_id, wallpaper_layout_override)
-            .await;
         app.router.relink_displays_to(&single, &renderer_id).await;
         wait_for_apply_frame(app, &renderer_id, first_frame_timeout).await?;
         first_renderer_id.get_or_insert(renderer_id);
@@ -998,7 +990,7 @@ pub async fn apply_wallpaper_with_options(
         .settings
         .plugin(&renderer_plugin_name)
         .unwrap_or_default();
-    let (user_properties_json, wallpaper_layout_override) =
+    let user_properties_json =
         repo::get_wallpaper_render_properties(&app.db, entry.item_id).await?;
     let spawn_req = renderer_manager::SpawnRequest {
         wp_type: entry.wp_type.clone(),
@@ -1020,21 +1012,13 @@ pub async fn apply_wallpaper_with_options(
     let duplicate_renderers =
         app.settings.global().duplicate_renderers_for_same_wallpaper && !target_ids.is_empty();
     let renderer_id = if duplicate_renderers {
-        apply_duplicate_renderers(
-            app,
-            &spawn_req,
-            &target_ids,
-            wallpaper_layout_override,
-            options.first_frame_timeout,
-        )
-        .await?
+        apply_duplicate_renderers(app, &spawn_req, &target_ids, options.first_frame_timeout).await?
     } else {
         apply_shared_renderer(
             app,
             spawn_req,
             target,
             &target_ids,
-            wallpaper_layout_override,
             options.first_frame_timeout,
         )
         .await?

--- a/src/event_process.rs
+++ b/src/event_process.rs
@@ -154,7 +154,18 @@ fn record(
 ) {
     let key = snap.instance_id.as_deref().unwrap_or(&snap.name);
     if locked {
-        if let Some(wp_id) = state.settings.resolved_lock_wallpaper(key) {
+        let key = key.to_string();
+        if !state
+            .settings
+            .display_prefs(&key)
+            .is_some_and(|p| p.has_lock_screen)
+        {
+            state.settings.update(|s| {
+                s.displays.entry(key.clone()).or_default().has_lock_screen = true;
+            });
+            state.events.publish(GlobalEvent::SettingsChanged);
+        }
+        if let Some(wp_id) = state.settings.resolved_lock_wallpaper(&key) {
             pending
                 .entry(wp_id)
                 .or_insert_with(|| (tokio::time::Instant::now(), Vec::new()))

--- a/src/event_process.rs
+++ b/src/event_process.rs
@@ -72,9 +72,10 @@ fn spawn_wallpaper_recall(state: Arc<AppState>) {
             let mut events_rx = state.router.subscribe_events();
 
             // Initial sweep of already-registered displays.
+            let locked = state.router.is_session_locked().await;
             for snap in state.router.snapshot_displays().await {
                 if seen.insert(snap.id) {
-                    record(&state, &mut pending, snap, SETTLE);
+                    record(&state, &mut pending, snap, locked, SETTLE);
                 }
             }
 
@@ -100,9 +101,10 @@ fn spawn_wallpaper_recall(state: Arc<AppState>) {
                                 return Ok(());
                             }
                         };
+                        let locked = state.router.is_session_locked().await;
                         for snap in snaps {
                             if seen.insert(snap.id) {
-                                record(&state, &mut pending, snap, SETTLE);
+                                record(&state, &mut pending, snap, locked, SETTLE);
                             }
                         }
                     }
@@ -147,9 +149,20 @@ fn record(
     state: &Arc<AppState>,
     pending: &mut HashMap<String, (tokio::time::Instant, Vec<scheduler::DisplayId>)>,
     snap: routing::DisplaySnapshot,
+    locked: bool,
     settle: Duration,
 ) {
     let key = snap.instance_id.as_deref().unwrap_or(&snap.name);
+    if locked {
+        if let Some(wp_id) = state.settings.resolved_lock_wallpaper(key) {
+            pending
+                .entry(wp_id)
+                .or_insert_with(|| (tokio::time::Instant::now(), Vec::new()))
+                .1
+                .push(snap.id);
+        }
+        return;
+    }
     let playlist_owned = state
         .settings
         .display_prefs(key)

--- a/src/model/entities/item.rs
+++ b/src/model/entities/item.rs
@@ -38,9 +38,6 @@ pub struct Model {
     /// JSON map of per-item user-property overrides. Each key is the
     /// shader's `u_*` uniform name (matches keys in the renderer's
     pub user_property_overrides: Option<String>,
-    /// JSON map of daemon-owned per-wallpaper display layout override.
-    /// This is intentionally separate from renderer user properties.
-    pub wallpaper_layout_override: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src/model/migration/m20260715_000001_drop_wallpaper_layout_override.rs
+++ b/src/model/migration/m20260715_000001_drop_wallpaper_layout_override.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Item::Table)
+                    .drop_column(Item::WallpaperLayoutOverride)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Item::Table)
+                    .add_column(ColumnDef::new(Item::WallpaperLayoutOverride).text().null())
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Item {
+    Table,
+    WallpaperLayoutOverride,
+}

--- a/src/model/migration/mod.rs
+++ b/src/model/migration/mod.rs
@@ -4,6 +4,7 @@ mod m20260503_000001_init_v2;
 mod m20260523_000001_user_property_overrides;
 mod m20260601_000001_playlists;
 mod m20260614_000001_wallpaper_layout_override;
+mod m20260715_000001_drop_wallpaper_layout_override;
 
 pub struct Migrator;
 
@@ -15,6 +16,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260523_000001_user_property_overrides::Migration),
             Box::new(m20260601_000001_playlists::Migration),
             Box::new(m20260614_000001_wallpaper_layout_override::Migration),
+            Box::new(m20260715_000001_drop_wallpaper_layout_override::Migration),
         ]
     }
 }
@@ -39,14 +41,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn item_wallpaper_layout_override_column_exists_after_migration() {
+    async fn item_wallpaper_layout_override_column_dropped_after_migration() {
         let db = crate::model::connect_url("sqlite::memory:").await.unwrap();
         let stmt = Statement::from_string(
             db.get_database_backend(),
             "SELECT wallpaper_layout_override FROM item LIMIT 0".to_string(),
         );
-        db.execute(stmt)
-            .await
-            .unwrap_or_else(|e| panic!("item.wallpaper_layout_override missing: {e}"));
+        assert!(
+            db.execute(stmt).await.is_err(),
+            "item.wallpaper_layout_override should be dropped by the migration"
+        );
     }
 }

--- a/src/model/repo.rs
+++ b/src/model/repo.rs
@@ -1011,92 +1011,25 @@ pub async fn get_user_property_overrides_raw(
         .map(|raw| crate::wallpaper::properties::normalize_user_property_overrides_json(&raw)))
 }
 
-fn parse_wallpaper_layout_override_raw(
-    item_id: i64,
-    raw: Option<&str>,
-) -> Option<crate::wallpaper::properties::WallpaperLayoutOverride> {
-    let raw = raw?.trim();
-    if raw.is_empty() {
-        return None;
-    }
-    let parsed = crate::wallpaper::properties::wallpaper_layout_override_from_json(raw);
-    if parsed.is_none() {
-        log::warn!("item {item_id}: wallpaper_layout_override JSON unparseable; ignoring");
-    }
-    parsed
-}
-
-/// Read renderer-owned user properties and daemon-owned layout data for
-/// renderer spawn/apply paths.
+/// Renderer user properties for spawn/apply, with daemon layout keys stripped out.
 pub async fn get_wallpaper_render_properties(
     db: &DatabaseConnection,
     item_id: i64,
-) -> Result<(
-    Option<String>,
-    crate::wallpaper::properties::WallpaperLayoutOverride,
-)> {
+) -> Result<Option<String>> {
     let row = item::Entity::find_by_id(item_id)
         .one(db)
         .await
         .with_context(|| format!("select item by id={item_id} for render properties"))?;
     let Some(item) = row else {
-        return Ok((None, Default::default()));
+        return Ok(None);
     };
     let raw_user_properties = item
         .user_property_overrides
         .as_deref()
         .map(crate::wallpaper::properties::normalize_user_property_overrides_json);
-    let (renderer_json, legacy_layout) =
-        crate::wallpaper::properties::split_renderer_properties(raw_user_properties.as_deref());
-    let layout =
-        parse_wallpaper_layout_override_raw(item_id, item.wallpaper_layout_override.as_deref())
-            .unwrap_or(legacy_layout);
-    Ok((renderer_json, layout))
-}
-
-/// Same layout read as `get_wallpaper_render_properties`, without the
-/// renderer-property payload. Used by detail responses.
-pub async fn get_wallpaper_layout_override_with_legacy(
-    db: &DatabaseConnection,
-    item_id: i64,
-) -> Result<Option<crate::wallpaper::properties::WallpaperLayoutOverride>> {
-    let (_, layout) = get_wallpaper_render_properties(db, item_id).await?;
-    Ok((!layout.is_empty()).then_some(layout))
-}
-
-pub async fn set_wallpaper_layout_override(
-    db: &DatabaseConnection,
-    item_id: i64,
-    layout: Option<crate::settings::ResolvedLayout>,
-) -> Result<()> {
-    let clearing = layout.is_none();
-    let serialized = layout
-        .map(crate::wallpaper::properties::wallpaper_layout_override_to_json)
-        .transpose()
-        .context("serialize wallpaper_layout_override")?;
-    let user_property_overrides = if clearing {
-        let mut current = get_user_property_overrides(db, item_id).await?;
-        current.retain(|k, _| !crate::wallpaper::properties::is_daemon_display_property_key(k));
-        let serialized = if current.is_empty() {
-            None
-        } else {
-            Some(serde_json::to_string(&current).context("serialize user_property_overrides")?)
-        };
-        Set(serialized)
-    } else {
-        NotSet
-    };
-    let active = item::ActiveModel {
-        id: Set(item_id),
-        wallpaper_layout_override: Set(serialized),
-        user_property_overrides,
-        ..Default::default()
-    };
-    item::Entity::update(active)
-        .exec(db)
-        .await
-        .with_context(|| format!("update item {item_id} wallpaper_layout_override"))?;
-    Ok(())
+    let renderer_json =
+        crate::wallpaper::properties::strip_daemon_layout_props(raw_user_properties.as_deref());
+    Ok(renderer_json)
 }
 
 /// Set or reset one item user-property override and rewrite the column.

--- a/src/routing/auto_replay.rs
+++ b/src/routing/auto_replay.rs
@@ -173,7 +173,11 @@ mod tests {
                     session_inactive: false,
                 },
             );
-            assert_eq!(decision.action, AutoAction::Mute, "configured={configured:?}");
+            assert_eq!(
+                decision.action,
+                AutoAction::Mute,
+                "configured={configured:?}"
+            );
         }
     }
 

--- a/src/routing/auto_replay.rs
+++ b/src/routing/auto_replay.rs
@@ -69,6 +69,13 @@ pub fn decide(policy: &AutoReplayPolicy, facts: Facts) -> Decision {
             best = Decision::from_action(action);
         }
     }
+    // While locked and still the active session, cap auto-replay at Mute so the reused lock renderer keeps drawing.
+    if facts.session_locked
+        && !facts.session_inactive
+        && best.action.priority() > AutoAction::Mute.priority()
+    {
+        best = Decision::from_action(AutoAction::Mute);
+    }
     best
 }
 
@@ -148,6 +155,68 @@ mod tests {
                 flags: FLAG_ACTIVE | FLAG_FULLSCREEN,
                 session_locked: false,
                 session_inactive: false,
+            },
+        );
+        assert_eq!(decision.action, AutoAction::Stop);
+    }
+
+    #[test]
+    fn session_lock_is_capped_at_mute() {
+        // Lock caps at Mute: no Stop, no Pause, so the renderer keeps drawing.
+        for configured in [AutoAction::Stop, AutoAction::Pause] {
+            let policy = policy(&[(AutoCondition::SessionLocked, configured)]);
+            let decision = decide(
+                &policy,
+                Facts {
+                    flags: 0,
+                    session_locked: true,
+                    session_inactive: false,
+                },
+            );
+            assert_eq!(decision.action, AutoAction::Mute, "configured={configured:?}");
+        }
+    }
+
+    #[test]
+    fn window_pause_is_capped_while_locked() {
+        // Don't let a fullscreen desktop window freeze the renderer while locked.
+        let policy = policy(&[(AutoCondition::Fullscreen, AutoAction::Stop)]);
+        let decision = decide(
+            &policy,
+            Facts {
+                flags: FLAG_FULLSCREEN,
+                session_locked: true,
+                session_inactive: false,
+            },
+        );
+        assert_eq!(decision.action, AutoAction::Mute);
+    }
+
+    #[test]
+    fn locked_and_inactive_still_stops() {
+        // Locked but switched away: the lock screen is hidden, so the stronger action stands.
+        let policy = policy(&[(AutoCondition::SessionInactive, AutoAction::Stop)]);
+        let decision = decide(
+            &policy,
+            Facts {
+                flags: 0,
+                session_locked: true,
+                session_inactive: true,
+            },
+        );
+        assert_eq!(decision.action, AutoAction::Stop);
+    }
+
+    #[test]
+    fn session_inactive_stop_still_kills() {
+        // The cap is lock-specific; user-switch (inactive) Stop is unchanged.
+        let policy = policy(&[(AutoCondition::SessionInactive, AutoAction::Stop)]);
+        let decision = decide(
+            &policy,
+            Facts {
+                flags: 0,
+                session_locked: false,
+                session_inactive: true,
             },
         );
         assert_eq!(decision.action, AutoAction::Stop);

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -320,28 +320,22 @@ impl Router {
                 rotation: Default::default(),
             };
         };
-        if let Some(iid) = info.instance_id.as_deref() {
-            if s.display_prefs(iid).is_some() {
-                return s.resolved_layout(iid);
-            }
+        let key = if let Some(iid) = info.instance_id.as_deref() {
             // No instance_id-keyed entry yet — fall back to the legacy
             // name-keyed entry so old config keeps working.
+            if s.display_prefs(iid).is_some() {
+                iid
+            } else {
+                info.name.as_str()
+            }
+        } else {
+            info.name.as_str()
+        };
+        if info.is_lock_screen {
+            s.resolved_lock_layout(key)
+        } else {
+            s.resolved_layout(key)
         }
-        s.resolved_layout(&info.name)
-    }
-
-    fn resolved_layout_for_renderer(
-        &self,
-        info: &DisplayInfo,
-        renderer_id: &str,
-        inner: &Inner,
-    ) -> ResolvedLayout {
-        inner
-            .wallpaper_layout_overrides
-            .get(renderer_id)
-            .copied()
-            .unwrap_or_default()
-            .apply_to(self.resolved_layout(info))
     }
 
     fn display_layout_source(&self, info: &DisplayInfo) -> LayoutSource {
@@ -353,12 +347,22 @@ impl Router {
         } else {
             s.display_prefs(&info.name)
         };
-        if prefs.as_ref().is_some_and(|p| {
-            p.fillmode.is_some()
-                || p.location.is_some()
-                || p.align.is_some()
-                || p.rotation.is_some()
-        }) {
+        let has_override = if info.is_lock_screen {
+            prefs.as_ref().is_some_and(|p| {
+                p.lock_fillmode.is_some()
+                    || p.lock_location.is_some()
+                    || p.lock_align.is_some()
+                    || p.lock_rotation.is_some()
+            })
+        } else {
+            prefs.as_ref().is_some_and(|p| {
+                p.fillmode.is_some()
+                    || p.location.is_some()
+                    || p.align.is_some()
+                    || p.rotation.is_some()
+            })
+        };
+        if has_override {
             LayoutSource::Display
         } else {
             LayoutSource::Global
@@ -403,6 +407,7 @@ impl Router {
         clear_fillmode: bool,
         clear_align: bool,
         clear_rotation: bool,
+        lock: bool,
     ) -> Option<DisplayId> {
         let Some(settings) = self.settings.get().cloned() else {
             log::warn!(
@@ -418,31 +423,60 @@ impl Router {
         };
         settings.update(|s| {
             let entry = s.displays.entry(key.clone()).or_default();
-            if clear_fillmode {
-                entry.fillmode = None;
-            }
-            if let Some(v) = new_fillmode {
-                entry.fillmode = Some(v);
-            }
-            if clear_align {
-                entry.location = None;
-                entry.align = None;
-            }
-            if let Some(v) = new_location {
-                entry.location = Some(v);
-                entry.align = None;
-            }
-            if let Some(v) = new_align {
-                if new_location.is_none() {
-                    entry.align = Some(v);
-                    entry.location = None;
+            if lock {
+                if clear_fillmode {
+                    entry.lock_fillmode = None;
                 }
-            }
-            if clear_rotation {
-                entry.rotation = None;
-            }
-            if let Some(v) = new_rotation {
-                entry.rotation = Some(v);
+                if let Some(v) = new_fillmode {
+                    entry.lock_fillmode = Some(v);
+                }
+                if clear_align {
+                    entry.lock_location = None;
+                    entry.lock_align = None;
+                }
+                if let Some(v) = new_location {
+                    entry.lock_location = Some(v);
+                    entry.lock_align = None;
+                }
+                if let Some(v) = new_align {
+                    if new_location.is_none() {
+                        entry.lock_align = Some(v);
+                        entry.lock_location = None;
+                    }
+                }
+                if clear_rotation {
+                    entry.lock_rotation = None;
+                }
+                if let Some(v) = new_rotation {
+                    entry.lock_rotation = Some(v);
+                }
+            } else {
+                if clear_fillmode {
+                    entry.fillmode = None;
+                }
+                if let Some(v) = new_fillmode {
+                    entry.fillmode = Some(v);
+                }
+                if clear_align {
+                    entry.location = None;
+                    entry.align = None;
+                }
+                if let Some(v) = new_location {
+                    entry.location = Some(v);
+                    entry.align = None;
+                }
+                if let Some(v) = new_align {
+                    if new_location.is_none() {
+                        entry.align = Some(v);
+                        entry.location = None;
+                    }
+                }
+                if clear_rotation {
+                    entry.rotation = None;
+                }
+                if let Some(v) = new_rotation {
+                    entry.rotation = Some(v);
+                }
             }
             // Prune empty entry to keep the on-disk file tidy.
             if entry.is_empty() {
@@ -790,6 +824,8 @@ impl Router {
                 refresh_mhz: reg.refresh_mhz,
                 properties: reg.properties,
                 bound: false,
+                // Registered while locked, so this is the lock surface; pin it for the display's lifetime.
+                is_lock_screen: inner.session_locked,
             };
             inner.displays.insert(
                 id,
@@ -2504,6 +2540,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false,
             )
             .await;
 
@@ -3043,6 +3080,7 @@ mod tests {
             refresh_mhz: 60_000,
             properties: vec![],
             bound: true,
+            is_lock_screen: false,
         }
     }
 

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -984,6 +984,10 @@ impl Router {
 
     /// Update the session-level state driven by the
     /// `session_monitor` task. `None` leaves that flag unchanged.
+    pub async fn is_session_locked(&self) -> bool {
+        self.inner.lock().await.session_locked
+    }
+
     pub async fn update_session_state(
         self: &Arc<Self>,
         locked: Option<bool>,

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -15,7 +15,6 @@ use crate::ipc::proto::{ControlMsg, EventMsg};
 use crate::renderer_manager::{DrmNode, RendererHandle, RendererId, RendererManager};
 use crate::scheduler::{DisplayId, DisplayInfo, ProjectedConfig};
 use crate::settings::{AutoAction, AutoReplayPolicy, ResolvedLayout, SettingsStore};
-use crate::wallpaper::properties::WallpaperLayoutOverride;
 
 use super::auto_replay;
 use super::table::{Link, LinkDstRect, LinkId, LinkSrcRect, RoutingTable};
@@ -246,7 +245,6 @@ struct Inner {
     /// Per-renderer set of (display_id, buffer_generation) pairs we've
     /// emitted `Unbind` for and are waiting to be acked.
     unbind_acks_pending: HashMap<RendererId, HashSet<(DisplayId, u64)>>,
-    wallpaper_layout_overrides: HashMap<RendererId, WallpaperLayoutOverride>,
     next_display_id: u64,
     next_config_generation: u64,
 }
@@ -285,7 +283,6 @@ impl Router {
                 renderer_states: HashMap::new(),
                 orphan_timers: HashMap::new(),
                 unbind_acks_pending: HashMap::new(),
-                wallpaper_layout_overrides: HashMap::new(),
                 next_display_id: 0,
                 next_config_generation: 0,
                 session_locked: false,
@@ -553,7 +550,7 @@ impl Router {
         inner.next_config_generation += 1;
         let cfg_gen = inner.next_config_generation;
         let info = inner.displays.get(&display_id).unwrap().info.clone();
-        let layout = self.resolved_layout_for_renderer(&info, &link.renderer_id, &inner);
+        let layout = self.resolved_layout(&info);
         let cfg = project_link(&link, &renderer, &info, cfg_gen, &layout);
         if let Some(state) = inner.displays.get(&display_id) {
             let _ = state.tx.send(DisplayOutEvent::SetConfig(cfg));
@@ -662,7 +659,6 @@ impl Router {
         let affected: Vec<DisplayId> = {
             let mut inner = self.inner.lock().await;
             let removed = inner.table.remove_renderer(id);
-            inner.wallpaper_layout_overrides.remove(id);
             if let Some(task) = inner.renderer_tasks.remove(id) {
                 task.abort();
             }
@@ -682,41 +678,6 @@ impl Router {
             let all = self.snapshot_displays().await;
             self.emit(RouterEvent::DisplaysReplace(all));
         }
-    }
-
-    pub async fn set_renderer_wallpaper_layout_override(
-        self: &Arc<Self>,
-        renderer_id: &str,
-        layout: WallpaperLayoutOverride,
-    ) -> bool {
-        let display_ids: Vec<DisplayId> = {
-            let mut inner = self.inner.lock().await;
-            if inner.table.get_renderer(renderer_id).is_none() {
-                return false;
-            }
-            if layout.is_empty() {
-                inner.wallpaper_layout_overrides.remove(renderer_id);
-            } else {
-                inner
-                    .wallpaper_layout_overrides
-                    .insert(renderer_id.to_string(), layout);
-            }
-            inner
-                .table
-                .links_for_renderer(renderer_id)
-                .into_iter()
-                .filter(|l| l.enabled)
-                .map(|l| l.display_id)
-                .collect()
-        };
-        for did in &display_ids {
-            self.resync_display_set_config(*did).await;
-        }
-        if !display_ids.is_empty() {
-            let all = self.snapshot_displays().await;
-            self.emit(RouterEvent::DisplaysReplace(all));
-        }
-        true
     }
 
     /// Arm `unbind_done` ack tracking for `renderer_id`. MUST be called
@@ -1464,19 +1425,7 @@ impl Router {
             .collect();
         let display_layout = self.resolved_layout(&s.info);
         let display_layout_source = self.display_layout_source(&s.info);
-        let wallpaper_layout_override = link_rows.first().and_then(|l| {
-            inner
-                .wallpaper_layout_overrides
-                .get(&l.renderer_id)
-                .copied()
-                .filter(|layout| !layout.is_empty())
-        });
-        let (effective_layout, effective_layout_source) =
-            if let Some(layout) = wallpaper_layout_override {
-                (layout.apply_to(display_layout), LayoutSource::Wallpaper)
-            } else {
-                (display_layout, display_layout_source)
-            };
+        let (effective_layout, effective_layout_source) = (display_layout, display_layout_source);
         let links = link_rows
             .into_iter()
             .map(|l| DisplayLinkSnapshot {
@@ -1571,19 +1520,8 @@ impl Router {
                     .collect();
                 let display_layout = self.resolved_layout(&s.info);
                 let display_layout_source = self.display_layout_source(&s.info);
-                let wallpaper_layout_override = link_rows.first().and_then(|l| {
-                    inner
-                        .wallpaper_layout_overrides
-                        .get(&l.renderer_id)
-                        .copied()
-                        .filter(|layout| !layout.is_empty())
-                });
                 let (effective_layout, effective_layout_source) =
-                    if let Some(layout) = wallpaper_layout_override {
-                        (layout.apply_to(display_layout), LayoutSource::Wallpaper)
-                    } else {
-                        (display_layout, display_layout_source)
-                    };
+                    (display_layout, display_layout_source);
                 let links = link_rows
                     .into_iter()
                     .map(|l| DisplayLinkSnapshot {
@@ -1805,7 +1743,7 @@ impl Router {
             }
             inner.next_config_generation += 1;
             let cfg_gen = inner.next_config_generation;
-            let layout = self.resolved_layout_for_renderer(&info, &link.renderer_id, &inner);
+            let layout = self.resolved_layout(&info);
             let cfg = project_link(&link, &renderer, &info, cfg_gen, &layout);
             Some((link.display_id, cfg))
         };
@@ -2260,7 +2198,7 @@ impl Router {
         if let Some((link, renderer, new_g)) = target {
             inner.next_config_generation += 1;
             let cfg_gen = inner.next_config_generation;
-            let layout = self.resolved_layout_for_renderer(&info, &link.renderer_id, &inner);
+            let layout = self.resolved_layout(&info);
             let cfg = project_link(&link, &renderer, &info, cfg_gen, &layout);
             let new_r = link.renderer_id.clone();
             let replay = renderer

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -19,6 +19,8 @@ pub struct DisplayInfo {
     /// Has the scheduler sent (or is about to send) `bind_buffers` to
     /// this display for the current `active_renderer` buffer pool?
     pub bound: bool,
+    /// True if this consumer registered while locked (the lock-screen surface).
+    pub is_lock_screen: bool,
 }
 
 /// Compact renderer-side buffer-pool description fanned out to clients.
@@ -112,6 +114,7 @@ impl Scheduler {
                 // New displays are bound immediately when an active
                 // renderer already exists.
                 bound: self.active.is_some(),
+                is_lock_screen: false,
             },
         );
         id

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -41,6 +41,8 @@ pub struct DisplayPrefs {
     /// Used to restore per-display assignment on restart.
     pub last_wallpaper: Option<String>,
     pub lock_wallpaper: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub has_lock_screen: bool,
     pub alias: Option<String>,
     pub active_playlist_id: Option<i64>,
 }
@@ -54,6 +56,7 @@ impl DisplayPrefs {
             && self.auto_replay.is_none()
             && self.last_wallpaper.is_none()
             && self.lock_wallpaper.is_none()
+            && !self.has_lock_screen
             && self.alias.is_none()
             && self.active_playlist_id.is_none()
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,6 +40,7 @@ pub struct DisplayPrefs {
     /// Last wallpaper id applied to this display.
     /// Used to restore per-display assignment on restart.
     pub last_wallpaper: Option<String>,
+    pub lock_wallpaper: Option<String>,
     pub alias: Option<String>,
     pub active_playlist_id: Option<i64>,
 }
@@ -52,6 +53,7 @@ impl DisplayPrefs {
             && self.rotation.is_none()
             && self.auto_replay.is_none()
             && self.last_wallpaper.is_none()
+            && self.lock_wallpaper.is_none()
             && self.alias.is_none()
             && self.active_playlist_id.is_none()
     }
@@ -153,6 +155,8 @@ impl AutoReplayPolicy {
 #[serde(default)]
 pub struct GlobalSettings {
     pub last_wallpaper: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock_wallpaper: Option<String>,
     /// Queue playback mode: `"sequential"` / `"shuffle"` / `"random"`.
     /// Restored on startup so the rotator resumes the same behavior.
     #[serde(alias = "playlist_mode")]
@@ -214,6 +218,7 @@ impl Default for GlobalSettings {
     fn default() -> Self {
         Self {
             last_wallpaper: None,
+            lock_wallpaper: None,
             queue_mode: "sequential".to_string(),
             rotation_secs: 0,
             audio_fade_ms: DEFAULT_AUDIO_FADE_MS,
@@ -694,6 +699,21 @@ impl SettingsStore {
         g.global.last_wallpaper.clone()
     }
 
+    pub fn resolved_lock_wallpaper(&self, display_key: &str) -> Option<String> {
+        {
+            let g = self.inner.read().expect("settings poisoned");
+            if let Some(id) = g
+                .displays
+                .get(display_key)
+                .and_then(|prefs| prefs.lock_wallpaper.clone())
+                .or_else(|| g.global.lock_wallpaper.clone())
+            {
+                return Some(id);
+            }
+        }
+        self.resolved_last_wallpaper(display_key)
+    }
+
     /// Snapshot just the cloned per-display preferences.
     /// Used to expose overrides over the control plane.
     pub fn display_prefs(&self, display_name: &str) -> Option<DisplayPrefs> {
@@ -1105,6 +1125,44 @@ fillmode = "preserve_aspect_fit"
         assert_eq!(
             store.resolved_last_wallpaper("DP-2").as_deref(),
             Some("wp-global"),
+        );
+    }
+
+    #[tokio::test]
+    async fn resolved_lock_wallpaper_falls_back_to_desktop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SettingsStore::load_or_default(tmp.path().join("config.toml")).await;
+
+        store.update(|s| {
+            s.global.last_wallpaper = Some("desktop".into());
+        });
+        assert_eq!(
+            store.resolved_lock_wallpaper("HDMI-A-1").as_deref(),
+            Some("desktop"),
+        );
+
+        store.update(|s| s.global.lock_wallpaper = Some("lock-global".into()));
+        assert_eq!(
+            store.resolved_lock_wallpaper("HDMI-A-1").as_deref(),
+            Some("lock-global"),
+        );
+
+        store.update(|s| {
+            s.displays.insert(
+                "HDMI-A-1".into(),
+                DisplayPrefs {
+                    lock_wallpaper: Some("lock-a".into()),
+                    ..Default::default()
+                },
+            );
+        });
+        assert_eq!(
+            store.resolved_lock_wallpaper("HDMI-A-1").as_deref(),
+            Some("lock-a"),
+        );
+        assert_eq!(
+            store.resolved_lock_wallpaper("DP-2").as_deref(),
+            Some("lock-global"),
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,11 @@ pub struct DisplayPrefs {
     pub lock_wallpaper: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub has_lock_screen: bool,
+    /// Per-display lock-screen layout override; unset fields fall back to the desktop layout.
+    pub lock_fillmode: Option<FillMode>,
+    pub lock_location: Option<Location>,
+    pub lock_align: Option<Align>,
+    pub lock_rotation: Option<Rotation>,
     pub alias: Option<String>,
     pub active_playlist_id: Option<i64>,
 }
@@ -57,6 +62,10 @@ impl DisplayPrefs {
             && self.last_wallpaper.is_none()
             && self.lock_wallpaper.is_none()
             && !self.has_lock_screen
+            && self.lock_fillmode.is_none()
+            && self.lock_location.is_none()
+            && self.lock_align.is_none()
+            && self.lock_rotation.is_none()
             && self.alias.is_none()
             && self.active_playlist_id.is_none()
     }
@@ -675,6 +684,30 @@ impl SettingsStore {
         }
     }
 
+    /// Resolve a display's lock-screen layout, falling back to its desktop layout.
+    pub fn resolved_lock_layout(&self, display_name: &str) -> ResolvedLayout {
+        let g = self.inner.read().expect("settings poisoned");
+        let defaults = &g.global.layout;
+        let prefs = g.displays.get(display_name);
+        let default_location = defaults
+            .location
+            .unwrap_or_else(|| Location::from_align(defaults.align));
+        let base_fillmode = prefs.and_then(|p| p.fillmode).unwrap_or(defaults.fillmode);
+        let base_location = prefs
+            .and_then(|p| p.location)
+            .or_else(|| prefs.and_then(|p| p.align.map(Location::from_align)))
+            .unwrap_or(default_location);
+        let base_rotation = prefs.and_then(|p| p.rotation).unwrap_or(defaults.rotation);
+        ResolvedLayout {
+            fillmode: prefs.and_then(|p| p.lock_fillmode).unwrap_or(base_fillmode),
+            location: prefs
+                .and_then(|p| p.lock_location)
+                .or_else(|| prefs.and_then(|p| p.lock_align.map(Location::from_align)))
+                .unwrap_or(base_location),
+            rotation: prefs.and_then(|p| p.lock_rotation).unwrap_or(base_rotation),
+        }
+    }
+
     pub fn resolved_auto_replay(&self, display_name: &str) -> AutoReplayPolicy {
         let g = self.inner.read().expect("settings poisoned");
         if let Some(policy) = g
@@ -1075,6 +1108,38 @@ fillmode = "preserve_aspect_fit"
         let r = store.resolved_layout("eDP-1");
         assert_eq!(r.fillmode, FillMode::PreserveAspectCrop); // override
         assert_eq!(r.location, Location::new(20, 80)); // global
+    }
+
+    #[tokio::test]
+    async fn resolved_lock_layout_falls_back_to_desktop_then_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        let store = SettingsStore::load_or_default(path).await;
+
+        // Desktop override set, no lock override => lock mirrors the desktop.
+        store.update(|s| {
+            s.displays.insert(
+                "eDP-1".into(),
+                DisplayPrefs {
+                    fillmode: Some(FillMode::PreserveAspectCrop),
+                    location: Some(Location::new(20, 80)),
+                    ..Default::default()
+                },
+            );
+        });
+        let r = store.resolved_lock_layout("eDP-1");
+        assert_eq!(r.fillmode, FillMode::PreserveAspectCrop);
+        assert_eq!(r.location, Location::new(20, 80));
+
+        // A lock override wins field by field over the desktop.
+        store.update(|s| {
+            let p = s.displays.get_mut("eDP-1").unwrap();
+            p.lock_fillmode = Some(FillMode::PreserveAspectFit);
+            p.lock_location = Some(Location::new(50, 50));
+        });
+        let r = store.resolved_lock_layout("eDP-1");
+        assert_eq!(r.fillmode, FillMode::PreserveAspectFit); // lock override
+        assert_eq!(r.location, Location::new(50, 50)); // lock override
     }
 
     #[test]

--- a/src/wallpaper/properties.rs
+++ b/src/wallpaper/properties.rs
@@ -1,9 +1,5 @@
 use std::collections::HashMap;
 
-use crate::display::layout::{FillMode, Location, Rotation};
-use crate::settings::ResolvedLayout;
-use serde::{Deserialize, Serialize};
-
 const SCHEME_COLOR_KEY: &str = "waywallen.scheme_color";
 const ENABLE_AUDIO_KEY: &str = "waywallen.enable_audio";
 const FILL_MODE_KEY: &str = "waywallen.fill_mode";
@@ -15,77 +11,6 @@ const LEGACY_SCHEME_COLOR_KEY: &str = "schemecolor";
 
 const DAEMON_LAYOUT_SCHEMA_KEYS: &[&str] =
     &[FILL_MODE_KEY, ROTATION_KEY, LOCATION_X_KEY, LOCATION_Y_KEY];
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
-#[serde(default)]
-pub struct WallpaperLayoutOverride {
-    pub fillmode: Option<FillMode>,
-    pub location: Option<Location>,
-    pub rotation: Option<Rotation>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-struct PersistedWallpaperLayoutOverride {
-    fillmode: FillMode,
-    location: Location,
-    rotation: Rotation,
-}
-
-impl WallpaperLayoutOverride {
-    pub fn from_resolved(layout: ResolvedLayout) -> Self {
-        Self {
-            fillmode: Some(layout.fillmode),
-            location: Some(layout.location),
-            rotation: Some(layout.rotation),
-        }
-    }
-
-    pub fn materialize(self) -> ResolvedLayout {
-        self.apply_to(ResolvedLayout {
-            fillmode: FillMode::default(),
-            location: Location::default(),
-            rotation: Rotation::default(),
-        })
-    }
-
-    pub fn apply_to(self, base: ResolvedLayout) -> ResolvedLayout {
-        ResolvedLayout {
-            fillmode: self.fillmode.unwrap_or(base.fillmode),
-            location: self.location.unwrap_or(base.location),
-            rotation: self.rotation.unwrap_or(base.rotation),
-        }
-    }
-
-    pub fn is_empty(self) -> bool {
-        self.fillmode.is_none() && self.location.is_none() && self.rotation.is_none()
-    }
-}
-
-pub fn wallpaper_layout_override_from_json(raw: &str) -> Option<WallpaperLayoutOverride> {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return None;
-    }
-    if let Ok(persisted) = serde_json::from_str::<PersistedWallpaperLayoutOverride>(raw) {
-        return Some(WallpaperLayoutOverride::from_resolved(ResolvedLayout {
-            fillmode: persisted.fillmode,
-            location: persisted.location,
-            rotation: persisted.rotation,
-        }));
-    }
-    let parsed = serde_json::from_str::<WallpaperLayoutOverride>(raw).ok()?;
-    (!parsed.is_empty()).then_some(parsed)
-}
-
-pub fn wallpaper_layout_override_to_json(
-    layout: ResolvedLayout,
-) -> Result<String, serde_json::Error> {
-    serde_json::to_string(&PersistedWallpaperLayoutOverride {
-        fillmode: layout.fillmode,
-        location: layout.location,
-        rotation: layout.rotation,
-    })
-}
 
 pub fn is_daemon_display_property_key(key: &str) -> bool {
     matches!(
@@ -231,83 +156,21 @@ pub fn normalize_user_property_overrides_json(raw: &str) -> String {
     serde_json::to_string(&value).unwrap_or_else(|_| raw.to_string())
 }
 
-pub fn split_renderer_properties(raw: Option<&str>) -> (Option<String>, WallpaperLayoutOverride) {
-    let Some(raw) = raw.filter(|v| !v.trim().is_empty()) else {
-        return (None, WallpaperLayoutOverride::default());
-    };
+pub fn strip_daemon_layout_props(raw: Option<&str>) -> Option<String> {
+    let raw = raw.filter(|v| !v.trim().is_empty())?;
     let Ok(map) = serde_json::from_str::<HashMap<String, String>>(raw) else {
-        return (Some(raw.to_string()), WallpaperLayoutOverride::default());
+        return Some(raw.to_string());
     };
 
-    let mut renderer = HashMap::new();
-    let mut fillmode = None;
-    let mut rotation = None;
-    let mut location_x = None;
-    let mut location_y = None;
-
-    for (key, value) in map {
-        match key.as_str() {
-            FILL_MODE_KEY => fillmode = parse_fillmode(&value),
-            ROTATION_KEY => rotation = parse_rotation(&value),
-            LOCATION_X_KEY => location_x = parse_percent(&value),
-            LOCATION_Y_KEY => location_y = parse_percent(&value),
-            _ => {
-                renderer.insert(key, value);
-            }
-        }
-    }
-
-    let location = if location_x.is_some() || location_y.is_some() {
-        Some(Location::new(
-            location_x.unwrap_or(50),
-            location_y.unwrap_or(50),
-        ))
-    } else {
-        None
-    };
-    let layout = WallpaperLayoutOverride {
-        fillmode,
-        location,
-        rotation,
-    };
-    let renderer_json = if renderer.is_empty() {
+    let renderer: HashMap<String, String> = map
+        .into_iter()
+        .filter(|(key, _)| !is_daemon_display_property_key(key))
+        .collect();
+    if renderer.is_empty() {
         None
     } else {
         serde_json::to_string(&renderer).ok()
-    };
-    (renderer_json, layout)
-}
-
-fn parse_fillmode(value: &str) -> Option<FillMode> {
-    match value {
-        "stretched" => Some(FillMode::Stretched),
-        "preserve_aspect_fit" => Some(FillMode::PreserveAspectFit),
-        "preserve_aspect_crop" => Some(FillMode::PreserveAspectCrop),
-        "centered" => Some(FillMode::Centered),
-        _ => None,
     }
-}
-
-fn parse_rotation(value: &str) -> Option<Rotation> {
-    match value {
-        "normal" => Some(Rotation::Normal),
-        "cw_90" => Some(Rotation::Cw90),
-        "cw_180" => Some(Rotation::Cw180),
-        "cw_270" => Some(Rotation::Cw270),
-        _ => None,
-    }
-}
-
-fn parse_percent(value: &str) -> Option<u8> {
-    let value = value.trim();
-    if value.is_empty() {
-        return None;
-    }
-    let parsed = value.parse::<f32>().ok()?;
-    if !parsed.is_finite() {
-        return None;
-    }
-    Some(parsed.round().clamp(0.0, 100.0) as u8)
 }
 
 #[cfg(test)]
@@ -322,9 +185,7 @@ mod tests {
             "waywallen.location_y": "75",
             "speed": "2"
         }"#;
-        let (renderer, layout) = split_renderer_properties(Some(raw));
-        assert_eq!(layout.fillmode, Some(FillMode::Centered));
-        assert_eq!(layout.location, Some(Location::new(25, 75)));
+        let renderer = strip_daemon_layout_props(Some(raw));
         assert_eq!(renderer.as_deref(), Some(r#"{"speed":"2"}"#));
     }
 
@@ -364,9 +225,7 @@ mod tests {
             "waywallen.enable_audio": "false",
             "waywallen.fill_mode": "centered"
         }"#;
-        let (renderer, layout) = split_renderer_properties(Some(raw));
-        assert_eq!(layout.fillmode, Some(FillMode::Centered));
-        let renderer = renderer.unwrap();
+        let renderer = strip_daemon_layout_props(Some(raw)).unwrap();
         let value: serde_json::Value = serde_json::from_str(&renderer).unwrap();
         assert_eq!(
             value

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -28,7 +28,6 @@ use crate::settings::{SettingsStore, WallpaperFilterState, WallpaperSortRuleStat
 use crate::tasks;
 use crate::wallpaper::properties::{
     dedupe_predefined_schema, is_daemon_display_property_key, user_property_default_wire_value,
-    WallpaperLayoutOverride,
 };
 use crate::wallpaper::sort::apply_wallpaper_sorts;
 use crate::AppState;
@@ -618,20 +617,6 @@ fn align_from_pb(v: i32) -> Option<crate::display::layout::Align> {
 
 fn location_from_pb(x: u32, y: u32) -> crate::display::layout::Location {
     crate::display::layout::Location::new(x.min(100) as u8, y.min(100) as u8)
-}
-
-fn resolved_layout_from_pb(p: &pb::LayoutPrefs) -> crate::settings::ResolvedLayout {
-    crate::settings::ResolvedLayout {
-        fillmode: fillmode_from_pb(p.fillmode).unwrap_or_default(),
-        location: if p.location_set {
-            location_from_pb(p.location_x, p.location_y)
-        } else {
-            align_from_pb(p.align)
-                .map(crate::display::layout::Location::from_align)
-                .unwrap_or_default()
-        },
-        rotation: rotation_from_pb(p.rotation).unwrap_or_default(),
-    }
 }
 
 fn auto_action_to_pb(v: crate::settings::AutoAction) -> pb::AutoAction {
@@ -1673,7 +1658,6 @@ async fn dispatch_inner(
                         tags,
                         String::new(),
                         String::new(),
-                        None,
                         remove_support_by_item
                             .get(&e.item_id)
                             .copied()
@@ -1711,8 +1695,6 @@ async fn dispatch_inner(
             let overrides = repo::get_user_property_overrides_raw(&state.db, entry.item_id)
                 .await?
                 .unwrap_or_default();
-            let layout_override =
-                repo::get_wallpaper_layout_override_with_legacy(&state.db, entry.item_id).await?;
 
             Res::WallpaperGet(pb::WallpaperGetResponse {
                 entry: Some(entry_to_pb(
@@ -1720,7 +1702,6 @@ async fn dispatch_inner(
                     tags,
                     schema,
                     overrides,
-                    layout_override,
                     supports_item_remove,
                 )),
             })
@@ -1776,15 +1757,9 @@ async fn dispatch_inner(
                 .find_by_resource(&entry.resource)
                 .await;
             let push_tag = if is_daemon_display_property_key(&r.key) {
+                // Per-wallpaper layout overrides are gone, so this no longer pushes to a live renderer.
                 if let Some(h) = live_renderer {
-                    let (_, wallpaper_layout_override) =
-                        repo::get_wallpaper_render_properties(&state.db, entry.item_id).await?;
-                    let id = h.id.clone();
-                    state
-                        .router
-                        .set_renderer_wallpaper_layout_override(&id, wallpaper_layout_override)
-                        .await;
-                    format!("display-layout={id}")
+                    format!("display-layout={}", h.id)
                 } else {
                     String::from("offline")
                 }
@@ -1842,55 +1817,6 @@ async fn dispatch_inner(
                 push_tag
             );
             Res::WallpaperPropertySet(pb::WallpaperPropertySetResponse {})
-        }
-
-        Req::WallpaperLayoutSet(r) => {
-            let entry = match r.wallpaper_id.parse::<i64>() {
-                Ok(iid) => repo::get_entry(&state.db, iid).await?,
-                Err(_) => None,
-            };
-            let entry = entry.ok_or_else(|| Error::WallpaperNotFound(r.wallpaper_id.clone()))?;
-            let layout = if r.clear {
-                None
-            } else {
-                let Some(layout) = r.layout.as_ref() else {
-                    return Err(Error::InvalidArgument(
-                        "wallpaper_layout_set requires layout unless clear=true".to_string(),
-                    ));
-                };
-                Some(resolved_layout_from_pb(layout))
-            };
-            repo::set_wallpaper_layout_override(&state.db, entry.item_id, layout).await?;
-
-            let live_renderer = state
-                .renderer_manager
-                .find_by_resource(&entry.resource)
-                .await;
-            if let Some(h) = live_renderer {
-                let override_layout = layout
-                    .map(WallpaperLayoutOverride::from_resolved)
-                    .unwrap_or_default();
-                state
-                    .router
-                    .set_renderer_wallpaper_layout_override(&h.id, override_layout)
-                    .await;
-            }
-
-            let layout_override = layout.map(WallpaperLayoutOverride::from_resolved);
-            let supports_item_remove = {
-                let sm = state.source_manager.lock().await;
-                sm.supports_item_remove(&entry.plugin_name)
-            };
-            Res::WallpaperLayoutSet(pb::WallpaperLayoutSetResponse {
-                entry: Some(entry_to_pb(
-                    &entry,
-                    entry.tags.clone(),
-                    String::new(),
-                    String::new(),
-                    layout_override,
-                    supports_item_remove,
-                )),
-            })
         }
 
         Req::WallpaperScan(_) => {
@@ -2795,12 +2721,10 @@ fn entry_to_pb(
     tags: Vec<String>,
     user_properties_schema: String,
     user_property_overrides: String,
-    wallpaper_layout_override: Option<WallpaperLayoutOverride>,
     supports_item_remove: bool,
 ) -> pb::WallpaperEntry {
     // `e` is reconstructed from the DB (the source of truth), so its
     // fields are already the freshest values — no overlay needed.
-    let wallpaper_layout_override_set = wallpaper_layout_override.is_some();
     pb::WallpaperEntry {
         id: e.item_id.to_string(),
         name: e.name.clone(),
@@ -2819,9 +2743,6 @@ fn entry_to_pb(
         user_property_overrides,
         description: e.description.clone().unwrap_or_default(),
         external_id: e.external_id.clone().unwrap_or_default(),
-        wallpaper_layout_override: wallpaper_layout_override
-            .map(|layout| layout_prefs_to_pb_resolved(&layout.materialize())),
-        wallpaper_layout_override_set,
         supports_item_remove,
     }
 }

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -443,6 +443,9 @@ fn display_snapshot_to_pb(s: DisplaySnapshot, settings: &SettingsStore) -> pb::D
         .filter(|iid| settings.display_prefs(iid).is_some())
         .unwrap_or(s.name.as_str());
     let override_prefs = settings.display_prefs(layout_key).unwrap_or_default();
+    let lock_display_layout =
+        layout_prefs_to_pb_resolved(&settings.resolved_lock_layout(layout_key));
+    let lock_layout_override = lock_layout_override_to_pb(&override_prefs);
     pb::DisplayInfo {
         display_id: s.id,
         name: s.name,
@@ -466,6 +469,8 @@ fn display_snapshot_to_pb(s: DisplaySnapshot, settings: &SettingsStore) -> pb::D
         effective_layout_source: layout_source_to_pb(s.effective_layout_source) as i32,
         lock_wallpaper: override_prefs.lock_wallpaper.clone().unwrap_or_default(),
         has_lock_screen: override_prefs.has_lock_screen,
+        lock_display_layout: Some(lock_display_layout),
+        lock_layout_override: Some(lock_layout_override),
     }
 }
 
@@ -503,6 +508,33 @@ fn layout_override_to_pb(p: &crate::settings::DisplayPrefs) -> pb::LayoutOverrid
         rotation_set: p.rotation.is_some(),
         rotation: p
             .rotation
+            .map(rotation_to_pb)
+            .unwrap_or(pb::Rotation::Unspecified) as i32,
+        location_set: location.is_some(),
+        location_x: location.map(|v| u32::from(v.x.min(100))).unwrap_or(0),
+        location_y: location.map(|v| u32::from(v.y.min(100))).unwrap_or(0),
+    }
+}
+
+fn lock_layout_override_to_pb(p: &crate::settings::DisplayPrefs) -> pb::LayoutOverride {
+    let location = p.lock_location.or_else(|| {
+        p.lock_align
+            .map(crate::display::layout::Location::from_align)
+    });
+    pb::LayoutOverride {
+        fillmode_set: p.lock_fillmode.is_some(),
+        fillmode: p
+            .lock_fillmode
+            .map(fillmode_to_pb)
+            .unwrap_or(pb::FillMode::Unspecified) as i32,
+        align_set: p.lock_align.is_some(),
+        align: p
+            .lock_align
+            .map(align_to_pb)
+            .unwrap_or(pb::Align::Unspecified) as i32,
+        rotation_set: p.lock_rotation.is_some(),
+        rotation: p
+            .lock_rotation
             .map(rotation_to_pb)
             .unwrap_or(pb::Rotation::Unspecified) as i32,
         location_set: location.is_some(),
@@ -1972,6 +2004,9 @@ async fn dispatch_inner(
                     .filter(|o| o.rotation_set)
                     .and_then(|o| rotation_from_pb(o.rotation))
             };
+            let lock = pb::LayoutLocation::try_from(r.location)
+                .map(|l| l == pb::LayoutLocation::Lock)
+                .unwrap_or(false);
             let target_id = state
                 .router
                 .set_display_layout(
@@ -1984,6 +2019,7 @@ async fn dispatch_inner(
                     r.clear_fillmode,
                     r.clear_align || r.clear_location,
                     r.clear_rotation,
+                    lock,
                 )
                 .await;
             let display = match target_id {

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -464,6 +464,8 @@ fn display_snapshot_to_pb(s: DisplaySnapshot, settings: &SettingsStore) -> pb::D
         alias: override_prefs.alias.clone().unwrap_or_default(),
         display_layout: Some(layout_prefs_to_pb_resolved(&s.display_layout)),
         effective_layout_source: layout_source_to_pb(s.effective_layout_source) as i32,
+        lock_wallpaper: override_prefs.lock_wallpaper.clone().unwrap_or_default(),
+        has_lock_screen: override_prefs.has_lock_screen,
     }
 }
 
@@ -2019,6 +2021,25 @@ async fn dispatch_inner(
                 None => None,
             };
             Res::DisplayRename(pb::DisplayRenameResponse { display })
+        }
+
+        Req::DisplayLockWallpaperSet(r) => {
+            let wallpaper_id = (!r.wallpaper_id.trim().is_empty()).then(|| r.wallpaper_id.clone());
+            let target = (!r.display_ids.is_empty()).then_some(r.display_ids.as_slice());
+            let target_ids = state.router.registered_display_ids(target).await;
+            let keys = state.router.display_settings_keys(&target_ids).await;
+            state.settings.update(|s| {
+                for (_, key) in &keys {
+                    let entry = s.displays.entry(key.clone()).or_default();
+                    entry.lock_wallpaper = wallpaper_id.clone();
+                    let empty = entry.is_empty();
+                    if empty {
+                        s.displays.remove(key);
+                    }
+                }
+            });
+            state.events.publish(GlobalEvent::SettingsChanged);
+            Res::DisplayLockWallpaperSet(pb::DisplayLockWallpaperSetResponse {})
         }
 
         Req::RemoteAvailability(_) => {

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -151,6 +151,7 @@ set(QML_FILES
   qml/component/ThumbnailImage.qml
   qml/component/SearchChip.qml
   qml/component/ValueSlider.qml
+  qml/component/DisplayLayoutSection.qml
   qml/component/filter/StringFilter.qml
   qml/component/filter/IntFilter.qml
   qml/component/filter/WpTypeFilter.qml

--- a/ui/qml/component/DisplayLayoutSection.qml
+++ b/ui/qml/component/DisplayLayoutSection.qml
@@ -1,0 +1,302 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Layouts
+import Qcm.Material as MD
+import waywallen.ui as W
+
+// Staged layout editor for one display + location; pushed by DisplaysPage's Apply.
+ColumnLayout {
+    id: section
+
+    // --- inputs ---
+    property var display: null // waywallen.Display
+    property int location: 0 // 0 = desktop, 1 = lock screen (proto LayoutLocation)
+    property string title: "Desktop"
+
+    // Read the layout live off `display` so reseed() sees fresh values, not a stale binding.
+    function readSource() {
+        if (!display)
+            return ({});
+        return location === 1 ? (display.lockDisplayLayout || ({})) : (display.displayLayout || display.effectiveLayout || ({}));
+    }
+    readonly property var srcOverride: {
+        if (!display)
+            return ({});
+        return location === 1 ? (display.lockLayoutOverride || ({})) : (display.layoutOverride || ({}));
+    }
+    // --- value tables (mirror proto FillMode / Rotation) ---
+    readonly property var kFillModeValues: [1, 2, 3, 7]
+    readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
+    readonly property var kRotationValues: [1, 2, 3, 4]
+    readonly property var kRotationLabels: ["0°", "90°", "180°", "270°"]
+    function fillmodeIndex(v) {
+        const i = kFillModeValues.indexOf(v);
+        return i < 0 ? 0 : i;
+    }
+    function clampPercent(v) {
+        return Math.max(0, Math.min(100, Math.round(Number(v) || 0)));
+    }
+
+    // --- staged vs. baseline ---
+    property int baseFillmode: 3
+    property int baseX: 50
+    property int baseY: 50
+    property int baseRotation: 1
+    property int stFillmode: 3
+    property int stX: 50
+    property int stY: 50
+    property int stRotation: 1
+
+    readonly property bool hasOverride: {
+        const o = srcOverride || ({});
+        return o.fillmodeSet === true || o.locationSet === true || o.alignSet === true || o.rotationSet === true;
+    }
+    readonly property bool dirty: stFillmode !== baseFillmode || stX !== baseX || stY !== baseY || stRotation !== baseRotation
+    readonly property bool locationEnabled: stFillmode !== 1 // not stretched
+
+    function reseed() {
+        const l = readSource();
+        const fm = Number(l.fillmode || 0);
+        baseFillmode = kFillModeValues.indexOf(fm) >= 0 ? fm : 3;
+        baseX = clampPercent(l.locationX ?? 50);
+        baseY = clampPercent(l.locationY ?? 50);
+        const rot = Number(l.rotation || 0);
+        baseRotation = kRotationValues.indexOf(rot) >= 0 ? rot : 1;
+        stFillmode = baseFillmode;
+        stX = baseX;
+        stY = baseY;
+        stRotation = baseRotation;
+    }
+
+    // Discard staged edits, back to the persisted values.
+    function discard() {
+        stFillmode = baseFillmode;
+        stX = baseX;
+        stY = baseY;
+        stRotation = baseRotation;
+    }
+
+    // Push only changed fields so the rest keep inheriting the global default.
+    function apply() {
+        if (!display || !dirty)
+            return;
+        setQuery.name = display.name;
+        setQuery.displayId = display.id;
+        setQuery.location = location;
+        setQuery.fillmodeSet = stFillmode !== baseFillmode;
+        setQuery.fillmode = stFillmode;
+        setQuery.locationSet = stX !== baseX || stY !== baseY;
+        setQuery.locationX = stX;
+        setQuery.locationY = stY;
+        setQuery.alignSet = false;
+        setQuery.rotationSet = stRotation !== baseRotation;
+        setQuery.rotation = stRotation;
+        setQuery.clearFillmode = false;
+        setQuery.clearLocation = false;
+        setQuery.clearAlign = false;
+        setQuery.clearRotation = false;
+        baseFillmode = stFillmode;
+        baseX = stX;
+        baseY = stY;
+        baseRotation = stRotation;
+        setQuery.reload();
+    }
+
+    // Clear this location's override, reverting to the global default.
+    function revertToGlobal() {
+        if (!display)
+            return;
+        discard();
+        setQuery.name = display.name;
+        setQuery.displayId = display.id;
+        setQuery.location = location;
+        setQuery.fillmodeSet = false;
+        setQuery.locationSet = false;
+        setQuery.alignSet = false;
+        setQuery.rotationSet = false;
+        setQuery.clearFillmode = true;
+        setQuery.clearLocation = true;
+        setQuery.clearAlign = true;
+        setQuery.clearRotation = true;
+        setQuery.reload();
+    }
+
+    spacing: 4
+
+    W.DisplayLayoutSetQuery {
+        id: setQuery
+    }
+
+    onDisplayChanged: reseed()
+    Component.onCompleted: reseed()
+
+    // Refresh the baseline on external updates, but never clobber a dirty edit.
+    Connections {
+        target: section.display
+        enabled: !!section.display
+        function onLayoutChanged() {
+            if (section.location === 0 && !section.dirty)
+                section.reseed();
+        }
+        function onLockLayoutChanged() {
+            if (section.location === 1 && !section.dirty)
+                section.reseed();
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        MD.Text {
+            text: section.title
+            typescale: MD.Token.typescale.label_large
+            color: MD.Token.color.on_surface
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        MD.IconButton {
+            mdState.size: MD.Enum.XS
+            enabled: section.hasOverride
+            icon.name: MD.Token.icon.refresh
+            MD.ToolTip {
+                visible: parent.hovered
+                text: "Revert to global default"
+            }
+            onClicked: section.revertToGlobal()
+        }
+    }
+
+    Flow {
+        Layout.fillWidth: true
+        spacing: 12
+
+        ColumnLayout {
+            width: Math.min(parent.width, 220)
+            spacing: 4
+
+            MD.Text {
+                text: "Fill mode"
+                typescale: MD.Token.typescale.label_medium
+                color: MD.Token.color.on_surface_variant
+            }
+
+            MD.ComboBox {
+                id: fillmodeBox
+                Layout.fillWidth: true
+                model: section.kFillModeLabels
+                onActivated: idx => section.stFillmode = section.kFillModeValues[idx]
+            }
+            // Restoring Binding keeps currentIndex on the staged value after the ComboBox writes it.
+            Binding {
+                target: fillmodeBox
+                property: "currentIndex"
+                value: section.fillmodeIndex(section.stFillmode)
+            }
+        }
+
+        ColumnLayout {
+            width: Math.min(parent.width, 260)
+            spacing: 4
+            enabled: section.locationEnabled
+            opacity: enabled ? 1.0 : 0.4
+
+            MD.Text {
+                text: "Horizontal"
+                typescale: MD.Token.typescale.label_medium
+                color: MD.Token.color.on_surface_variant
+            }
+
+            W.ValueSlider {
+                id: hSlider
+                Layout.fillWidth: true
+                from: 0
+                to: 100
+                stepSize: 1
+                valueText: section.clampPercent(value)
+                valueMaxText: "100"
+                valueHorizontalAlignment: Text.AlignLeft
+                onMoved: section.stX = section.clampPercent(value)
+            }
+            Binding {
+                target: hSlider
+                property: "value"
+                value: section.stX
+            }
+        }
+
+        ColumnLayout {
+            width: Math.min(parent.width, 260)
+            spacing: 4
+            enabled: section.locationEnabled
+            opacity: enabled ? 1.0 : 0.4
+
+            MD.Text {
+                text: "Vertical"
+                typescale: MD.Token.typescale.label_medium
+                color: MD.Token.color.on_surface_variant
+            }
+
+            W.ValueSlider {
+                id: vSlider
+                Layout.fillWidth: true
+                from: 0
+                to: 100
+                stepSize: 1
+                valueText: section.clampPercent(value)
+                valueMaxText: "100"
+                valueHorizontalAlignment: Text.AlignLeft
+                onMoved: section.stY = section.clampPercent(value)
+            }
+            Binding {
+                target: vSlider
+                property: "value"
+                value: section.stY
+            }
+        }
+
+        ColumnLayout {
+            width: Math.min(parent.width, implicitWidth)
+            spacing: 4
+
+            MD.Text {
+                text: "Rotation"
+                typescale: MD.Token.typescale.label_medium
+                color: MD.Token.color.on_surface_variant
+            }
+
+            MD.SegmentedButtonGroup {
+                size: MD.Enum.XS
+
+                // checkable:false stops the ButtonGroup overwriting the staged `checked` binding.
+                MD.SegmentedButton {
+                    checkable: false
+                    text: section.kRotationLabels[0]
+                    checked: section.stRotation === section.kRotationValues[0]
+                    onClicked: section.stRotation = section.kRotationValues[0]
+                }
+                MD.SegmentedButton {
+                    checkable: false
+                    text: section.kRotationLabels[1]
+                    checked: section.stRotation === section.kRotationValues[1]
+                    onClicked: section.stRotation = section.kRotationValues[1]
+                }
+                MD.SegmentedButton {
+                    checkable: false
+                    text: section.kRotationLabels[2]
+                    checked: section.stRotation === section.kRotationValues[2]
+                    onClicked: section.stRotation = section.kRotationValues[2]
+                }
+                MD.SegmentedButton {
+                    checkable: false
+                    text: section.kRotationLabels[3]
+                    checked: section.stRotation === section.kRotationValues[3]
+                    onClicked: section.stRotation = section.kRotationValues[3]
+                }
+            }
+        }
+    }
+}

--- a/ui/qml/page/DisplaysPage.qml
+++ b/ui/qml/page/DisplaysPage.qml
@@ -22,56 +22,6 @@ MD.Page {
     readonly property real displayPaneHeight: detailsVisible ? paneAvailableHeight / 3 : paneAvailableHeight
     readonly property real detailPaneHeight: detailsVisible ? paneAvailableHeight - displayPaneHeight : 0
 
-    // FillMode/Rotation enum values mirror proto::FillMode /
-    // proto::Rotation (control.proto). Keep the *_VALUES
-    // arrays in lockstep with the enum order; *_LABELS is what the UI
-    // shows.
-    readonly property var kFillModeValues: [1 // STRETCHED
-        , 2 // PRESERVE_ASPECT_FIT
-        , 3 // PRESERVE_ASPECT_CROP
-        , 7  // CENTERED
-    ]
-    readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
-    function fillmodeIndex(value) {
-        const i = root.kFillModeValues.indexOf(value);
-        return i < 0 ? 0 : i;
-    }
-
-    // Rotation segmented values, mirror proto::Rotation:
-    //   1=NORMAL, 2=CW_90, 3=CW_180, 4=CW_270
-    readonly property var kRotationValues: [1, 2, 3, 4]
-    readonly property var kRotationLabels: ["0°", "90°", "180°", "270°"]
-    function rotationIndex(value) {
-        const i = root.kRotationValues.indexOf(value);
-        return i < 0 ? 0 : i;
-    }
-
-    function clampPercent(value) {
-        return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
-    }
-
-    function applyLocation(x, y) {
-        if (!root.selected)
-            return;
-        layoutSetQuery.name = root.selected.name;
-        layoutSetQuery.displayId = root.selected.id;
-        layoutSetQuery.fillmodeSet = false;
-        layoutSetQuery.locationSet = true;
-        layoutSetQuery.locationX = root.clampPercent(x);
-        layoutSetQuery.locationY = root.clampPercent(y);
-        layoutSetQuery.alignSet = false;
-        layoutSetQuery.rotationSet = false;
-        layoutSetQuery.clearFillmode = false;
-        layoutSetQuery.clearLocation = false;
-        layoutSetQuery.clearAlign = false;
-        layoutSetQuery.clearRotation = false;
-        layoutSetQuery.reload();
-    }
-
-    W.DisplayLayoutSetQuery {
-        id: layoutSetQuery
-    }
-
     W.DisplayRenameQuery {
         id: renameQuery
     }
@@ -310,8 +260,13 @@ MD.Page {
                 }
             }
 
-            contentItem: MD.Flickable2 {
+            contentItem: ColumnLayout {
+                spacing: 0
+
+                MD.Flickable2 {
                 id: detailsFlick
+                Layout.fillWidth: true
+                Layout.fillHeight: true
                 clip: true
                 contentWidth: width
                 contentHeight: root.selected ? detailsContent.implicitHeight : 0
@@ -592,7 +547,7 @@ MD.Page {
                         }
                     }
 
-                    // ---- Layout (fillmode + location) ----
+                    // ---- Layout (staged; applied per location on demand) ----
                     MD.Divider {
                         Layout.fillWidth: true
                         Layout.topMargin: 8
@@ -600,229 +555,75 @@ MD.Page {
                         visible: !!root.selected
                     }
 
-                    RowLayout {
+                    MD.Text {
+                        visible: !!root.selected
+                        text: "Layout"
+                        typescale: MD.Token.typescale.title_small
+                        color: MD.Token.color.on_surface
+                    }
+
+                    W.DisplayLayoutSection {
+                        id: desktopLayout
                         Layout.fillWidth: true
                         visible: !!root.selected
-                        spacing: 8
+                        display: root.selected
+                        location: 0
+                        title: "Desktop"
+                    }
 
-                        MD.Text {
-                            Layout.fillWidth: true
-                            text: "Layout"
-                            typescale: MD.Token.typescale.title_small
-                            color: MD.Token.color.on_surface
-                        }
+                    MD.Divider {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 8
+                        Layout.bottomMargin: 4
+                        visible: lockLayout.visible
+                    }
 
-                        MD.AssistChip {
-                            visible: !!root.selected && root.selected.layoutOverriddenByWallpaper
-                            text: "Wallpaper override"
-                        }
+                    W.DisplayLayoutSection {
+                        id: lockLayout
+                        Layout.fillWidth: true
+                        visible: !!root.selected && root.selected.hasLockScreen === true
+                        display: root.selected
+                        location: 1
+                        title: "Lock screen"
+                    }
 
-                        Item {
-                            implicitWidth: children[0].implicitWidth
-                            MD.IconButton {
-                                anchors.verticalCenter: parent.verticalCenter
-                                mdState.size: MD.Enum.XS
-                                enabled: {
-                                    if (!root.selected)
-                                        return false;
-                                    const ovr = root.selected.layoutOverride || ({});
-                                    return ovr.fillmodeSet === true || ovr.locationSet === true || ovr.alignSet === true || ovr.rotationSet === true;
-                                }
-                                icon.name: MD.Token.icon.refresh
-                                MD.ToolTip {
-                                    visible: parent.hovered
-                                    text: "Revert to global default"
-                                }
-                                onClicked: {
-                                    if (!root.selected)
-                                        return;
-                                    layoutSetQuery.name = root.selected.name;
-                                    layoutSetQuery.displayId = root.selected.id;
-                                    layoutSetQuery.fillmodeSet = false;
-                                    layoutSetQuery.locationSet = false;
-                                    layoutSetQuery.alignSet = false;
-                                    layoutSetQuery.clearFillmode = true;
-                                    layoutSetQuery.clearLocation = true;
-                                    layoutSetQuery.clearAlign = true;
-                                    layoutSetQuery.clearRotation = true;
-                                    layoutSetQuery.reload();
-                                }
-                            }
+                }
+                }
+
+                // Pinned action bar so Apply stays reachable when the sections scroll.
+                RowLayout {
+                    id: layoutActions
+                    readonly property bool anyDirty: desktopLayout.dirty || (lockLayout.visible && lockLayout.dirty)
+                    Layout.fillWidth: true
+                    Layout.topMargin: 8
+                    Layout.bottomMargin: 8
+                    visible: !!root.selected
+                    spacing: 8
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    MD.Button {
+                        mdState.type: MD.Enum.BtText
+                        text: "Revert"
+                        enabled: layoutActions.anyDirty
+                        onClicked: {
+                            desktopLayout.discard();
+                            if (lockLayout.visible)
+                                lockLayout.discard();
                         }
                     }
 
-                    Flow {
-                        id: layoutFlow
-                        readonly property var displayLayout: root.selected ? (root.selected.displayLayout || root.selected.effectiveLayout || ({})) : ({})
-                        readonly property int currentX: root.clampPercent(displayLayout.locationX ?? 50)
-                        readonly property int currentY: root.clampPercent(displayLayout.locationY ?? 50)
-                        readonly property bool locationEnabled: {
-                            if (!root.selected)
-                                return false;
-                            const layout = root.selected.displayLayout || root.selected.effectiveLayout || ({});
-                            return (layout.fillmode || 0) !== 1;
-                        }
-                        Layout.fillWidth: true
-                        visible: !!root.selected
-                        spacing: 12
-
-                        ColumnLayout {
-                            width: Math.min(layoutFlow.width, 220)
-                            spacing: 4
-
-                            MD.Text {
-                                text: "Fill mode"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            MD.ComboBox {
-                                id: fillmodeBox
-                                Layout.fillWidth: true
-                                model: root.kFillModeLabels
-                                currentIndex: {
-                                    if (!root.selected)
-                                        return 0;
-                                    const layout = root.selected.displayLayout || root.selected.effectiveLayout || ({});
-                                    return root.fillmodeIndex(layout.fillmode || 0);
-                                }
-                                onActivated: idx => {
-                                    if (!root.selected)
-                                        return;
-                                    layoutSetQuery.name = root.selected.name;
-                                    layoutSetQuery.displayId = root.selected.id;
-                                    layoutSetQuery.fillmodeSet = true;
-                                    layoutSetQuery.fillmode = root.kFillModeValues[idx];
-                                    layoutSetQuery.locationSet = false;
-                                    layoutSetQuery.alignSet = false;
-                                    layoutSetQuery.rotationSet = false;
-                                    layoutSetQuery.clearFillmode = false;
-                                    layoutSetQuery.clearLocation = false;
-                                    layoutSetQuery.clearAlign = false;
-                                    layoutSetQuery.clearRotation = false;
-                                    layoutSetQuery.reload();
-                                }
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(layoutFlow.width, 260)
-                            spacing: 4
-
-                            enabled: layoutFlow.locationEnabled
-                            opacity: enabled ? 1.0 : 0.4
-
-                            MD.Text {
-                                text: "Horizontal"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            W.ValueSlider {
-                                id: horizontalLocation
-                                Layout.fillWidth: true
-                                from: 0
-                                to: 100
-                                stepSize: 1
-                                value: layoutFlow.currentX
-                                valueText: root.clampPercent(value)
-                                valueMaxText: root.clampPercent(to).toString()
-                                valueHorizontalAlignment: Text.AlignLeft
-                                onMoved: root.applyLocation(value, verticalLocation.value)
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(layoutFlow.width, 260)
-                            spacing: 4
-
-                            enabled: layoutFlow.locationEnabled
-                            opacity: enabled ? 1.0 : 0.4
-
-                            MD.Text {
-                                text: "Vertical"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            W.ValueSlider {
-                                id: verticalLocation
-                                Layout.fillWidth: true
-                                from: 0
-                                to: 100
-                                stepSize: 1
-                                value: layoutFlow.currentY
-                                valueText: root.clampPercent(value)
-                                valueMaxText: root.clampPercent(to).toString()
-                                valueHorizontalAlignment: Text.AlignLeft
-                                onMoved: root.applyLocation(horizontalLocation.value, value)
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(layoutFlow.width, implicitWidth)
-                            spacing: 4
-
-                            MD.Text {
-                                text: "Rotation"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            MD.SegmentedButtonGroup {
-                                id: rotationGroup
-                                size: MD.Enum.XS
-
-                                // Inline buttons; SegmentedButtonGroup's
-                                // updatePositions only recognises segmented
-                                // buttons that are direct children — a
-                                // Repeater here ends up in contentModel as
-                                // an extra slot and shifts PosFirst off the
-                                // real first button.
-                                function applyRotation(rotationValue) {
-                                    if (!root.selected)
-                                        return;
-                                    layoutSetQuery.name = root.selected.name;
-                                    layoutSetQuery.displayId = root.selected.id;
-                                    layoutSetQuery.fillmodeSet = false;
-                                    layoutSetQuery.locationSet = false;
-                                    layoutSetQuery.alignSet = false;
-                                    layoutSetQuery.rotationSet = true;
-                                    layoutSetQuery.rotation = rotationValue;
-                                    layoutSetQuery.clearFillmode = false;
-                                    layoutSetQuery.clearLocation = false;
-                                    layoutSetQuery.clearAlign = false;
-                                    layoutSetQuery.clearRotation = false;
-                                    layoutSetQuery.reload();
-                                }
-                                function isChecked(rotationValue) {
-                                    if (!root.selected)
-                                        return rotationValue === 1; // ROTATION_NORMAL
-                                    const layout = root.selected.displayLayout || root.selected.effectiveLayout || ({});
-                                    return (layout.rotation || 0) === rotationValue;
-                                }
-
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[0]
-                                    checked: rotationGroup.isChecked(root.kRotationValues[0])
-                                    onClicked: rotationGroup.applyRotation(root.kRotationValues[0])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[1]
-                                    checked: rotationGroup.isChecked(root.kRotationValues[1])
-                                    onClicked: rotationGroup.applyRotation(root.kRotationValues[1])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[2]
-                                    checked: rotationGroup.isChecked(root.kRotationValues[2])
-                                    onClicked: rotationGroup.applyRotation(root.kRotationValues[2])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[3]
-                                    checked: rotationGroup.isChecked(root.kRotationValues[3])
-                                    onClicked: rotationGroup.applyRotation(root.kRotationValues[3])
-                                }
-                            }
+                    MD.Button {
+                        mdState.type: MD.Enum.BtFilledTonal
+                        text: "Apply"
+                        enabled: layoutActions.anyDirty
+                        onClicked: {
+                            if (desktopLayout.dirty)
+                                desktopLayout.apply();
+                            if (lockLayout.visible && lockLayout.dirty)
+                                lockLayout.apply();
                         }
                     }
                 }

--- a/ui/qml/page/WallpaperDetailPanel.qml
+++ b/ui/qml/page/WallpaperDetailPanel.qml
@@ -21,48 +21,17 @@ Item {
     property var applyTargetIds: []
     property int rendererIndex: 0
     property string applyTarget: "desktop"
-    readonly property bool showLockTarget: {
+    readonly property bool showLockTarget: root.lockTargetIds.length > 0
+    // Apply targets, plus the lock-capable subset used for the lock-screen target.
+    readonly property var lockTargetIds: {
         const all = W.App.displayManager.displays || [];
         const targets = root.applyTargetIds.length === 0
             ? all
             : all.filter(d => root.applyTargetIds.indexOf(d.id) >= 0);
-        return targets.some(d => !!d && d.hasLockScreen === true);
+        return targets.filter(d => !!d && d.hasLockScreen === true).map(d => d.id);
     }
-    readonly property var kFillModeValues: [1, 2, 3, 7]
-    readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
-    readonly property var kRotationValues: [1, 2, 3, 4]
-    readonly property var kRotationLabels: ["0°", "90°", "180°", "270°"]
-    readonly property bool wallpaperLayoutOverrideSet: root.wp?.wallpaperLayoutOverrideSet ?? false
-    readonly property var wallpaperLayout: wallpaperLayoutOverrideSet
-        ? (root.wp?.wallpaperLayoutOverride ?? ({}))
-        : ({ fillmode: 3, locationX: 50, locationY: 50, rotation: 1, locationSet: true })
 
     function isTargetAll() { return root.applyTargetIds.length === 0; }
-    function fillmodeIndex(value) {
-        const i = root.kFillModeValues.indexOf(value);
-        return i < 0 ? 2 : i;
-    }
-    function clampPercent(value) {
-        return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
-    }
-    function applyWallpaperLayout(fillmode, x, y, rotation) {
-        if (!root.wp)
-            return;
-        layoutSetQuery.wallpaperId = root.wallpaperId;
-        layoutSetQuery.clear = false;
-        layoutSetQuery.fillmode = fillmode;
-        layoutSetQuery.locationX = root.clampPercent(x);
-        layoutSetQuery.locationY = root.clampPercent(y);
-        layoutSetQuery.rotation = rotation;
-        layoutSetQuery.reload();
-    }
-    function resetWallpaperLayout() {
-        if (!root.wp)
-            return;
-        layoutSetQuery.wallpaperId = root.wallpaperId;
-        layoutSetQuery.clear = true;
-        layoutSetQuery.reload();
-    }
     function toggleTarget(id) {
         const next = root.applyTargetIds.slice();
         const i = next.indexOf(id);
@@ -185,21 +154,6 @@ Item {
         id: setQuery
     }
 
-    W.WallpaperLayoutSetQuery {
-        id: layoutSetQuery
-        wallpaperId: root.wallpaperId
-    }
-
-    Connections {
-        target: layoutSetQuery
-        function onStatusChanged() {
-            if (layoutSetQuery.status === 2)
-                wallpaperGetQuery.reload();
-            else if (layoutSetQuery.status === 3)
-                W.Action.toast("Layout update failed");
-        }
-    }
-
     Connections {
         target: W.Notify
         function onPluginChanged() {
@@ -286,8 +240,9 @@ Item {
                 }
                 applyQuery.reload();
             }
-            if (target === "lock" || target === "both") {
-                lockWallpaperQuery.displayIds = root.applyTargetIds;
+            if ((target === "lock" || target === "both") && root.lockTargetIds.length > 0) {
+                // Only the lock-capable subset of the targeted displays.
+                lockWallpaperQuery.displayIds = root.lockTargetIds;
                 lockWallpaperQuery.wallpaperId = root.wp.id_proto;
                 lockWallpaperQuery.reload();
             }
@@ -567,182 +522,6 @@ Item {
                     }
                 }
 
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 8
-                    visible: (root.wp?.id_proto ?? "") !== ""
-
-                    MD.Divider { Layout.fillWidth: true }
-
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 4
-
-                        MD.Text {
-                            Layout.fillWidth: true
-                            text: "Layout override"
-                            typescale: MD.Token.typescale.label_large
-                            color: MD.Token.color.on_surface_variant
-                        }
-
-                        MD.IconButton {
-                            icon.name: MD.Token.icon.restart_alt
-                            mdState.size: MD.Enum.XS
-                            enabled: root.wallpaperLayoutOverrideSet
-                            onClicked: root.resetWallpaperLayout()
-
-                            MD.ToolTip {
-                                visible: parent.hovered
-                                text: "Reset to display layout"
-                            }
-                        }
-                    }
-
-                    Flow {
-                        id: m_wallpaper_layout_flow
-                        Layout.fillWidth: true
-                        spacing: 12
-
-                        readonly property var layout: root.wallpaperLayout || ({})
-                        readonly property int currentFillmode: Number(layout.fillmode ?? 3)
-                        readonly property int currentRotation: Number(layout.rotation ?? 1)
-                        readonly property int currentX: root.clampPercent(layout.locationX ?? 50)
-                        readonly property int currentY: root.clampPercent(layout.locationY ?? 50)
-                        readonly property bool locationEnabled: currentFillmode !== 1
-
-                        ColumnLayout {
-                            width: Math.min(m_wallpaper_layout_flow.width, 220)
-                            spacing: 4
-
-                            MD.Text {
-                                text: "Fill mode"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            MD.ComboBox {
-                                Layout.fillWidth: true
-                                model: root.kFillModeLabels
-                                currentIndex: root.fillmodeIndex(m_wallpaper_layout_flow.currentFillmode)
-                                onActivated: idx => {
-                                    root.applyWallpaperLayout(
-                                        root.kFillModeValues[idx],
-                                        m_wallpaper_layout_flow.currentX,
-                                        m_wallpaper_layout_flow.currentY,
-                                        m_wallpaper_layout_flow.currentRotation);
-                                }
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(m_wallpaper_layout_flow.width, 260)
-                            spacing: 4
-                            enabled: m_wallpaper_layout_flow.locationEnabled
-                            opacity: enabled ? 1.0 : 0.4
-
-                            MD.Text {
-                                text: "Horizontal"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            W.ValueSlider {
-                                id: wallpaperHorizontalLocation
-                                Layout.fillWidth: true
-                                from: 0
-                                to: 100
-                                stepSize: 1
-                                value: m_wallpaper_layout_flow.currentX
-                                valueText: root.clampPercent(value)
-                                valueMaxText: root.clampPercent(to).toString()
-                                valueHorizontalAlignment: Text.AlignLeft
-                                onMoved: root.applyWallpaperLayout(
-                                    m_wallpaper_layout_flow.currentFillmode,
-                                    value,
-                                    wallpaperVerticalLocation.value,
-                                    m_wallpaper_layout_flow.currentRotation)
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(m_wallpaper_layout_flow.width, 260)
-                            spacing: 4
-                            enabled: m_wallpaper_layout_flow.locationEnabled
-                            opacity: enabled ? 1.0 : 0.4
-
-                            MD.Text {
-                                text: "Vertical"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            W.ValueSlider {
-                                id: wallpaperVerticalLocation
-                                Layout.fillWidth: true
-                                from: 0
-                                to: 100
-                                stepSize: 1
-                                value: m_wallpaper_layout_flow.currentY
-                                valueText: root.clampPercent(value)
-                                valueMaxText: root.clampPercent(to).toString()
-                                valueHorizontalAlignment: Text.AlignLeft
-                                onMoved: root.applyWallpaperLayout(
-                                    m_wallpaper_layout_flow.currentFillmode,
-                                    wallpaperHorizontalLocation.value,
-                                    value,
-                                    m_wallpaper_layout_flow.currentRotation)
-                            }
-                        }
-
-                        ColumnLayout {
-                            width: Math.min(m_wallpaper_layout_flow.width, implicitWidth)
-                            spacing: 4
-
-                            MD.Text {
-                                text: "Rotation"
-                                typescale: MD.Token.typescale.label_medium
-                                color: MD.Token.color.on_surface_variant
-                            }
-
-                            MD.SegmentedButtonGroup {
-                                id: wallpaperRotationGroup
-                                size: MD.Enum.XS
-
-                                function applyRotation(rotationValue) {
-                                    root.applyWallpaperLayout(
-                                        m_wallpaper_layout_flow.currentFillmode,
-                                        m_wallpaper_layout_flow.currentX,
-                                        m_wallpaper_layout_flow.currentY,
-                                        rotationValue);
-                                }
-                                function isChecked(rotationValue) {
-                                    return m_wallpaper_layout_flow.currentRotation === rotationValue;
-                                }
-
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[0]
-                                    checked: wallpaperRotationGroup.isChecked(root.kRotationValues[0])
-                                    onClicked: wallpaperRotationGroup.applyRotation(root.kRotationValues[0])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[1]
-                                    checked: wallpaperRotationGroup.isChecked(root.kRotationValues[1])
-                                    onClicked: wallpaperRotationGroup.applyRotation(root.kRotationValues[1])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[2]
-                                    checked: wallpaperRotationGroup.isChecked(root.kRotationValues[2])
-                                    onClicked: wallpaperRotationGroup.applyRotation(root.kRotationValues[2])
-                                }
-                                MD.SegmentedButton {
-                                    text: root.kRotationLabels[3]
-                                    checked: wallpaperRotationGroup.isChecked(root.kRotationValues[3])
-                                    onClicked: wallpaperRotationGroup.applyRotation(root.kRotationValues[3])
-                                }
-                            }
-                        }
-                    }
-                }
             }
 
             section.property: "section"

--- a/ui/qml/page/WallpaperDetailPanel.qml
+++ b/ui/qml/page/WallpaperDetailPanel.qml
@@ -20,6 +20,14 @@ Item {
 
     property var applyTargetIds: []
     property int rendererIndex: 0
+    property string applyTarget: "desktop"
+    readonly property bool showLockTarget: {
+        const all = W.App.displayManager.displays || [];
+        const targets = root.applyTargetIds.length === 0
+            ? all
+            : all.filter(d => root.applyTargetIds.indexOf(d.id) >= 0);
+        return targets.some(d => !!d && d.hasLockScreen === true);
+    }
     readonly property var kFillModeValues: [1, 2, 3, 7]
     readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
     readonly property var kRotationValues: [1, 2, 3, 4]
@@ -113,9 +121,24 @@ Item {
     W.RendererPluginListQuery { id: pluginQuery }
     W.WallpaperApplyQuery { id: applyQuery }
     W.WallpaperApplyViaPortalQuery { id: portalApplyQuery }
+    W.DisplayLockWallpaperSetQuery { id: lockWallpaperQuery }
     W.WallpaperRemoveQuery {
         id: removeQuery
         wallpaperId: root.wallpaperId
+    }
+
+    Connections {
+        target: lockWallpaperQuery
+        function onStatusChanged() {
+            if (lockWallpaperQuery.status === 2) {
+                wallpaperGetQuery.reload();
+            } else if (lockWallpaperQuery.status === 3) {
+                const message = lockWallpaperQuery.error && lockWallpaperQuery.error.length > 0
+                    ? lockWallpaperQuery.error
+                    : qsTr("Apply failed");
+                W.Action.toast(message, 6000, 1, null);
+            }
+        }
     }
 
     Connections {
@@ -246,20 +269,28 @@ Item {
     MD.Action {
         id: applyAction
         text: "Apply"
-        busy: applyQuery.querying
+        busy: applyQuery.querying || lockWallpaperQuery.querying
         enabled: (W.App.displayManager.displays || []).length > 0
         onTriggered: {
             if (busy) return;
             if (!root.wp) return;
-            applyQuery.wallpaper = root.wp;
-            applyQuery.displayIds = root.applyTargetIds;
-            if (root.rendererCandidates.length >= 2) {
-                const pick = root.rendererCandidates[root.rendererIndex];
-                applyQuery.rendererName = pick ? (pick.name || "") : "";
-            } else {
-                applyQuery.rendererName = "";
+            const target = root.showLockTarget ? root.applyTarget : "desktop";
+            if (target === "desktop" || target === "both") {
+                applyQuery.wallpaper = root.wp;
+                applyQuery.displayIds = root.applyTargetIds;
+                if (root.rendererCandidates.length >= 2) {
+                    const pick = root.rendererCandidates[root.rendererIndex];
+                    applyQuery.rendererName = pick ? (pick.name || "") : "";
+                } else {
+                    applyQuery.rendererName = "";
+                }
+                applyQuery.reload();
             }
-            applyQuery.reload();
+            if (target === "lock" || target === "both") {
+                lockWallpaperQuery.displayIds = root.applyTargetIds;
+                lockWallpaperQuery.wallpaperId = root.wp.id_proto;
+                lockWallpaperQuery.reload();
+            }
         }
     }
 
@@ -944,6 +975,42 @@ Item {
                             checked: root.applyTargetIds.indexOf(modelData?.id) >= 0
                             onClicked: root.toggleTarget(modelData?.id)
                         }
+                    }
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+                visible: root.showLockTarget
+
+                MD.Text {
+                    text: "Set as"
+                    typescale: MD.Token.typescale.label_medium
+                    color: MD.Token.color.on_surface_variant
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    MD.FilterChip {
+                        checkable: false
+                        text: "Both"
+                        checked: root.applyTarget === "both"
+                        onClicked: root.applyTarget = "both"
+                    }
+                    MD.FilterChip {
+                        checkable: false
+                        text: "Desktop"
+                        checked: root.applyTarget === "desktop"
+                        onClicked: root.applyTarget = "desktop"
+                    }
+                    MD.FilterChip {
+                        checkable: false
+                        text: "Lock Screen"
+                        checked: root.applyTarget === "lock"
+                        onClicked: root.applyTarget = "lock"
                     }
                 }
             }

--- a/ui/src/objmodel/display.cpp
+++ b/ui/src/objmodel/display.cpp
@@ -55,10 +55,6 @@ auto Display::displayLayoutFromPb(const proto::DisplayInfo& info) -> QVariantMap
     return m;
 }
 
-auto Display::layoutOverriddenByWallpaperFromPb(const proto::DisplayInfo& info) -> bool {
-    return info.effectiveLayoutSource() == proto::LayoutSource::LAYOUT_SOURCE_WALLPAPER;
-}
-
 auto Display::layoutOverrideFromPb(const proto::DisplayInfo& info) -> QVariantMap {
     QVariantMap m;
     if (! info.hasLayoutOverride()) return m;
@@ -171,14 +167,12 @@ void Display::updateFrom(const proto::DisplayInfo& info) {
     }
     auto new_eff            = effectiveLayoutFromPb(info);
     auto new_display_layout = displayLayoutFromPb(info);
-    auto new_overridden     = layoutOverriddenByWallpaperFromPb(info);
     auto new_ovr            = layoutOverrideFromPb(info);
     if (m_effective_layout != new_eff || m_display_layout != new_display_layout ||
-        m_layout_overridden_by_wallpaper != new_overridden || m_layout_override != new_ovr) {
-        m_effective_layout               = std::move(new_eff);
-        m_display_layout                 = std::move(new_display_layout);
-        m_layout_overridden_by_wallpaper = new_overridden;
-        m_layout_override                = std::move(new_ovr);
+        m_layout_override != new_ovr) {
+        m_effective_layout = std::move(new_eff);
+        m_display_layout   = std::move(new_display_layout);
+        m_layout_override  = std::move(new_ovr);
         Q_EMIT layoutChanged();
     }
     if (m_lock_wallpaper != info.lockWallpaper()) {

--- a/ui/src/objmodel/display.cpp
+++ b/ui/src/objmodel/display.cpp
@@ -75,6 +75,34 @@ auto Display::layoutOverrideFromPb(const proto::DisplayInfo& info) -> QVariantMa
     return m;
 }
 
+auto Display::lockDisplayLayoutFromPb(const proto::DisplayInfo& info) -> QVariantMap {
+    QVariantMap m;
+    if (! info.hasLockDisplayLayout()) return m;
+    const auto& l     = info.lockDisplayLayout();
+    m[u"fillmode"_s]  = static_cast<int>(l.fillmode());
+    m[u"align"_s]     = static_cast<int>(l.align());
+    m[u"locationX"_s] = l.locationX();
+    m[u"locationY"_s] = l.locationY();
+    m[u"rotation"_s]  = static_cast<int>(l.rotation());
+    return m;
+}
+
+auto Display::lockLayoutOverrideFromPb(const proto::DisplayInfo& info) -> QVariantMap {
+    QVariantMap m;
+    if (! info.hasLockLayoutOverride()) return m;
+    const auto& o       = info.lockLayoutOverride();
+    m[u"fillmodeSet"_s] = o.fillmodeSet();
+    m[u"fillmode"_s]    = static_cast<int>(o.fillmode());
+    m[u"alignSet"_s]    = o.alignSet();
+    m[u"align"_s]       = static_cast<int>(o.align());
+    m[u"locationSet"_s] = o.locationSet();
+    m[u"locationX"_s]   = o.locationX();
+    m[u"locationY"_s]   = o.locationY();
+    m[u"rotationSet"_s] = o.rotationSet();
+    m[u"rotation"_s]    = static_cast<int>(o.rotation());
+    return m;
+}
+
 auto Display::playlistStatusFromPb(const proto::PlaylistDisplayStatus* status) -> QVariantMap {
     QVariantMap m;
     if (! status || status->activeId() <= 0) return m;
@@ -99,12 +127,13 @@ Display::Display(const proto::DisplayInfo& info, QObject* parent)
       m_links(linksFromPb(info)),
       m_effective_layout(effectiveLayoutFromPb(info)),
       m_display_layout(displayLayoutFromPb(info)),
-      m_layout_overridden_by_wallpaper(layoutOverriddenByWallpaperFromPb(info)),
       m_layout_override(layoutOverrideFromPb(info)),
       m_drm_render_major(info.drmRenderMajor()),
       m_drm_render_minor(info.drmRenderMinor()),
       m_lock_wallpaper(info.lockWallpaper()),
-      m_has_lock_screen(info.hasLockScreen()) {}
+      m_has_lock_screen(info.hasLockScreen()),
+      m_lock_display_layout(lockDisplayLayoutFromPb(info)),
+      m_lock_layout_override(lockLayoutOverrideFromPb(info)) {}
 
 void Display::updateFrom(const proto::DisplayInfo& info) {
     rstd_assert(info.displayId() == m_id, "Display::updateFrom id mismatch");
@@ -159,6 +188,14 @@ void Display::updateFrom(const proto::DisplayInfo& info) {
     if (m_has_lock_screen != info.hasLockScreen()) {
         m_has_lock_screen = info.hasLockScreen();
         Q_EMIT hasLockScreenChanged();
+    }
+    auto new_lock_layout   = lockDisplayLayoutFromPb(info);
+    auto new_lock_override = lockLayoutOverrideFromPb(info);
+    if (m_lock_display_layout != new_lock_layout ||
+        m_lock_layout_override != new_lock_override) {
+        m_lock_display_layout  = std::move(new_lock_layout);
+        m_lock_layout_override = std::move(new_lock_override);
+        Q_EMIT lockLayoutChanged();
     }
 }
 

--- a/ui/src/objmodel/display.cpp
+++ b/ui/src/objmodel/display.cpp
@@ -103,7 +103,8 @@ Display::Display(const proto::DisplayInfo& info, QObject* parent)
       m_layout_override(layoutOverrideFromPb(info)),
       m_drm_render_major(info.drmRenderMajor()),
       m_drm_render_minor(info.drmRenderMinor()),
-      m_lock_wallpaper(info.lockWallpaper()) {}
+      m_lock_wallpaper(info.lockWallpaper()),
+      m_has_lock_screen(info.hasLockScreen()) {}
 
 void Display::updateFrom(const proto::DisplayInfo& info) {
     rstd_assert(info.displayId() == m_id, "Display::updateFrom id mismatch");
@@ -154,6 +155,10 @@ void Display::updateFrom(const proto::DisplayInfo& info) {
     if (m_lock_wallpaper != info.lockWallpaper()) {
         m_lock_wallpaper = info.lockWallpaper();
         Q_EMIT lockWallpaperChanged();
+    }
+    if (m_has_lock_screen != info.hasLockScreen()) {
+        m_has_lock_screen = info.hasLockScreen();
+        Q_EMIT hasLockScreenChanged();
     }
 }
 

--- a/ui/src/objmodel/display.cpp
+++ b/ui/src/objmodel/display.cpp
@@ -102,7 +102,8 @@ Display::Display(const proto::DisplayInfo& info, QObject* parent)
       m_layout_overridden_by_wallpaper(layoutOverriddenByWallpaperFromPb(info)),
       m_layout_override(layoutOverrideFromPb(info)),
       m_drm_render_major(info.drmRenderMajor()),
-      m_drm_render_minor(info.drmRenderMinor()) {}
+      m_drm_render_minor(info.drmRenderMinor()),
+      m_lock_wallpaper(info.lockWallpaper()) {}
 
 void Display::updateFrom(const proto::DisplayInfo& info) {
     rstd_assert(info.displayId() == m_id, "Display::updateFrom id mismatch");
@@ -149,6 +150,10 @@ void Display::updateFrom(const proto::DisplayInfo& info) {
         m_layout_overridden_by_wallpaper = new_overridden;
         m_layout_override                = std::move(new_ovr);
         Q_EMIT layoutChanged();
+    }
+    if (m_lock_wallpaper != info.lockWallpaper()) {
+        m_lock_wallpaper = info.lockWallpaper();
+        Q_EMIT lockWallpaperChanged();
     }
 }
 

--- a/ui/src/objmodel/display.cppm
+++ b/ui/src/objmodel/display.cppm
@@ -53,6 +53,7 @@ class Display : public QObject {
     Q_PROPERTY(qint64 activePlaylistId READ activePlaylistId NOTIFY playlistStatusChanged FINAL)
     Q_PROPERTY(QVariantMap playlistStatus READ playlistStatus NOTIFY playlistStatusChanged FINAL)
     Q_PROPERTY(QString lockWallpaper READ lockWallpaper NOTIFY lockWallpaperChanged FINAL)
+    Q_PROPERTY(bool hasLockScreen READ hasLockScreen NOTIFY hasLockScreenChanged FINAL)
 
 public:
     explicit Display(const proto::DisplayInfo& info, QObject* parent = nullptr);
@@ -74,6 +75,7 @@ public:
     auto activePlaylistId() const -> qint64 { return m_active_playlist_id; }
     auto playlistStatus() const -> const QVariantMap& { return m_playlist_status; }
     auto lockWallpaper() const -> const QString& { return m_lock_wallpaper; }
+    auto hasLockScreen() const -> bool { return m_has_lock_screen; }
 
     /// Diff-update from a freshly-received `DisplayInfo`. Only emits
     /// the signals for properties that actually changed.
@@ -89,6 +91,7 @@ public:
     Q_SIGNAL void layoutChanged();
     Q_SIGNAL void playlistStatusChanged();
     Q_SIGNAL void lockWallpaperChanged();
+    Q_SIGNAL void hasLockScreenChanged();
 
 private:
     static auto linksFromPb(const proto::DisplayInfo& info) -> QVariantList;
@@ -114,6 +117,7 @@ private:
     qint64       m_active_playlist_id { 0 };
     QVariantMap  m_playlist_status;
     QString      m_lock_wallpaper;
+    bool         m_has_lock_screen { false };
 };
 
 /// Singleton model for all currently-registered displays. Fed by:

--- a/ui/src/objmodel/display.cppm
+++ b/ui/src/objmodel/display.cppm
@@ -54,6 +54,10 @@ class Display : public QObject {
     Q_PROPERTY(QVariantMap playlistStatus READ playlistStatus NOTIFY playlistStatusChanged FINAL)
     Q_PROPERTY(QString lockWallpaper READ lockWallpaper NOTIFY lockWallpaperChanged FINAL)
     Q_PROPERTY(bool hasLockScreen READ hasLockScreen NOTIFY hasLockScreenChanged FINAL)
+    /// Resolved lock-screen layout; the Displays-tab lock section binds here.
+    Q_PROPERTY(QVariantMap lockDisplayLayout READ lockDisplayLayout NOTIFY lockLayoutChanged FINAL)
+    /// Sparse per-display lock-screen layout override.
+    Q_PROPERTY(QVariantMap lockLayoutOverride READ lockLayoutOverride NOTIFY lockLayoutChanged FINAL)
 
 public:
     explicit Display(const proto::DisplayInfo& info, QObject* parent = nullptr);
@@ -76,6 +80,8 @@ public:
     auto playlistStatus() const -> const QVariantMap& { return m_playlist_status; }
     auto lockWallpaper() const -> const QString& { return m_lock_wallpaper; }
     auto hasLockScreen() const -> bool { return m_has_lock_screen; }
+    auto lockDisplayLayout() const -> const QVariantMap& { return m_lock_display_layout; }
+    auto lockLayoutOverride() const -> const QVariantMap& { return m_lock_layout_override; }
 
     /// Diff-update from a freshly-received `DisplayInfo`. Only emits
     /// the signals for properties that actually changed.
@@ -92,13 +98,15 @@ public:
     Q_SIGNAL void playlistStatusChanged();
     Q_SIGNAL void lockWallpaperChanged();
     Q_SIGNAL void hasLockScreenChanged();
+    Q_SIGNAL void lockLayoutChanged();
 
 private:
     static auto linksFromPb(const proto::DisplayInfo& info) -> QVariantList;
     static auto effectiveLayoutFromPb(const proto::DisplayInfo& info) -> QVariantMap;
     static auto displayLayoutFromPb(const proto::DisplayInfo& info) -> QVariantMap;
-    static auto layoutOverriddenByWallpaperFromPb(const proto::DisplayInfo& info) -> bool;
     static auto layoutOverrideFromPb(const proto::DisplayInfo& info) -> QVariantMap;
+    static auto lockDisplayLayoutFromPb(const proto::DisplayInfo& info) -> QVariantMap;
+    static auto lockLayoutOverrideFromPb(const proto::DisplayInfo& info) -> QVariantMap;
     static auto playlistStatusFromPb(const proto::PlaylistDisplayStatus* status) -> QVariantMap;
 
     quint64      m_id;
@@ -118,6 +126,8 @@ private:
     QVariantMap  m_playlist_status;
     QString      m_lock_wallpaper;
     bool         m_has_lock_screen { false };
+    QVariantMap  m_lock_display_layout;
+    QVariantMap  m_lock_layout_override;
 };
 
 /// Singleton model for all currently-registered displays. Fed by:

--- a/ui/src/objmodel/display.cppm
+++ b/ui/src/objmodel/display.cppm
@@ -52,6 +52,7 @@ class Display : public QObject {
     Q_PROPERTY(quint32 drmRenderMinor READ drmRenderMinor CONSTANT FINAL)
     Q_PROPERTY(qint64 activePlaylistId READ activePlaylistId NOTIFY playlistStatusChanged FINAL)
     Q_PROPERTY(QVariantMap playlistStatus READ playlistStatus NOTIFY playlistStatusChanged FINAL)
+    Q_PROPERTY(QString lockWallpaper READ lockWallpaper NOTIFY lockWallpaperChanged FINAL)
 
 public:
     explicit Display(const proto::DisplayInfo& info, QObject* parent = nullptr);
@@ -72,6 +73,7 @@ public:
     auto drmRenderMinor() const -> quint32 { return m_drm_render_minor; }
     auto activePlaylistId() const -> qint64 { return m_active_playlist_id; }
     auto playlistStatus() const -> const QVariantMap& { return m_playlist_status; }
+    auto lockWallpaper() const -> const QString& { return m_lock_wallpaper; }
 
     /// Diff-update from a freshly-received `DisplayInfo`. Only emits
     /// the signals for properties that actually changed.
@@ -86,6 +88,7 @@ public:
     Q_SIGNAL void linksChanged();
     Q_SIGNAL void layoutChanged();
     Q_SIGNAL void playlistStatusChanged();
+    Q_SIGNAL void lockWallpaperChanged();
 
 private:
     static auto linksFromPb(const proto::DisplayInfo& info) -> QVariantList;
@@ -110,6 +113,7 @@ private:
     quint32      m_drm_render_minor;
     qint64       m_active_playlist_id { 0 };
     QVariantMap  m_playlist_status;
+    QString      m_lock_wallpaper;
 };
 
 /// Singleton model for all currently-registered displays. Fed by:

--- a/ui/src/objmodel/display.cppm
+++ b/ui/src/objmodel/display.cppm
@@ -40,8 +40,6 @@ class Display : public QObject {
     /// `fillmode` (int), `locationX` / `locationY` (0..100).
     Q_PROPERTY(QVariantMap effectiveLayout READ effectiveLayout NOTIFY layoutChanged FINAL)
     Q_PROPERTY(QVariantMap displayLayout READ displayLayout NOTIFY layoutChanged FINAL)
-    Q_PROPERTY(bool layoutOverriddenByWallpaper READ layoutOverriddenByWallpaper NOTIFY
-                   layoutChanged FINAL)
     /// Sparse per-display override. Same key set as effectiveLayout
     /// plus `fillmodeSet` / `locationSet` booleans
     /// indicating whether each field is explicitly overridden vs. inherited.
@@ -72,7 +70,6 @@ public:
     auto links() const -> const QVariantList& { return m_links; }
     auto effectiveLayout() const -> const QVariantMap& { return m_effective_layout; }
     auto displayLayout() const -> const QVariantMap& { return m_display_layout; }
-    auto layoutOverriddenByWallpaper() const -> bool { return m_layout_overridden_by_wallpaper; }
     auto layoutOverride() const -> const QVariantMap& { return m_layout_override; }
     auto drmRenderMajor() const -> quint32 { return m_drm_render_major; }
     auto drmRenderMinor() const -> quint32 { return m_drm_render_minor; }
@@ -118,7 +115,6 @@ private:
     QVariantList m_links;
     QVariantMap  m_effective_layout;
     QVariantMap  m_display_layout;
-    bool         m_layout_overridden_by_wallpaper { false };
     QVariantMap  m_layout_override;
     quint32      m_drm_render_major;
     quint32      m_drm_render_minor;

--- a/ui/src/proto.cppm
+++ b/ui/src/proto.cppm
@@ -44,8 +44,6 @@ using proto::WallpaperApplyViaPortalResponse;
 using proto::WallpaperEntry;
 using proto::WallpaperGetRequest;
 using proto::WallpaperGetResponse;
-using proto::WallpaperLayoutSetRequest;
-using proto::WallpaperLayoutSetResponse;
 using proto::WallpaperListRequest;
 using proto::WallpaperListResponse;
 using proto::WallpaperPropertySetRequest;

--- a/ui/src/proto.cppm
+++ b/ui/src/proto.cppm
@@ -145,6 +145,7 @@ using proto::AlignGadget::Align;
 using proto::AutoActionGadget::AutoAction;
 using proto::FillModeGadget::FillMode;
 using proto::LayoutSourceGadget::LayoutSource;
+using proto::LayoutLocationGadget::LayoutLocation;
 using proto::RotationGadget::Rotation;
 
 using proto::FilterLogic;

--- a/ui/src/proto.cppm
+++ b/ui/src/proto.cppm
@@ -73,6 +73,8 @@ using proto::DisplayListRequest;
 using proto::DisplayListResponse;
 using proto::DisplayRenameRequest;
 using proto::DisplayRenameResponse;
+using proto::DisplayLockWallpaperSetRequest;
+using proto::DisplayLockWallpaperSetResponse;
 using proto::LayoutOverride;
 
 using proto::RemoteAvailabilityRequest;

--- a/ui/src/query/display_query.cpp
+++ b/ui/src/query/display_query.cpp
@@ -1,5 +1,6 @@
 module;
 #include "waywallen/query/display_query.moc.h"
+#include <qtprotobuftypes.h>
 #undef assert
 #include <rstd/macro.hpp>
 #include <algorithm>
@@ -196,8 +197,7 @@ DisplayLockWallpaperSetQuery::DisplayLockWallpaperSetQuery(QObject* parent): Que
         }                           \
     } while (0)
 
-void DisplayLockWallpaperSetQuery::setName(const QString& v) { WW_SET(m_name, v); }
-void DisplayLockWallpaperSetQuery::setDisplayId(quint64 v) { WW_SET(m_display_id, v); }
+void DisplayLockWallpaperSetQuery::setDisplayIds(const QVariantList& v) { WW_SET(m_display_ids, v); }
 void DisplayLockWallpaperSetQuery::setWallpaperId(const QString& v) { WW_SET(m_wallpaper_id, v); }
 #undef WW_SET
 
@@ -206,8 +206,14 @@ void DisplayLockWallpaperSetQuery::reload() {
     auto backend = App::instance()->backend();
 
     proto::DisplayLockWallpaperSetRequest inner;
-    inner.setName(m_name);
-    inner.setDisplayId(m_display_id);
+    QtProtobuf::uint64List ids;
+    ids.reserve(m_display_ids.size());
+    for (const auto& v : m_display_ids) {
+        bool ok = false;
+        auto id = v.toULongLong(&ok);
+        if (ok) ids.append(id);
+    }
+    inner.setDisplayIds(ids);
     inner.setWallpaperId(m_wallpaper_id);
 
     auto req = proto::Request {};

--- a/ui/src/query/display_query.cpp
+++ b/ui/src/query/display_query.cpp
@@ -186,6 +186,46 @@ void DisplayRenameQuery::reload() {
     });
 }
 
+DisplayLockWallpaperSetQuery::DisplayLockWallpaperSetQuery(QObject* parent): Query(parent) {}
+
+#define WW_SET(field, val)          \
+    do {                            \
+        if (this->field != val) {   \
+            this->field = val;      \
+            Q_EMIT paramsChanged(); \
+        }                           \
+    } while (0)
+
+void DisplayLockWallpaperSetQuery::setName(const QString& v) { WW_SET(m_name, v); }
+void DisplayLockWallpaperSetQuery::setDisplayId(quint64 v) { WW_SET(m_display_id, v); }
+void DisplayLockWallpaperSetQuery::setWallpaperId(const QString& v) { WW_SET(m_wallpaper_id, v); }
+#undef WW_SET
+
+void DisplayLockWallpaperSetQuery::reload() {
+    setStatus(Status::Querying);
+    auto backend = App::instance()->backend();
+
+    proto::DisplayLockWallpaperSetRequest inner;
+    inner.setName(m_name);
+    inner.setDisplayId(m_display_id);
+    inner.setWallpaperId(m_wallpaper_id);
+
+    auto req = proto::Request {};
+    req.setDisplayLockWallpaperSet(std::move(inner));
+
+    auto self = QWatcher { this };
+    spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
+        auto result = co_await backend->send(std::move(req));
+        co_await asio::post(asio::bind_executor(QAsyncResult::get_executor(), use_task));
+        if (! self) co_return;
+
+        self->inspect_set(result, [](const proto::Response& rsp) {
+            (void)rsp;
+        });
+        co_return;
+    });
+}
+
 } // namespace waywallen
 
 #include "waywallen/query/display_query.moc.cpp"

--- a/ui/src/query/display_query.cpp
+++ b/ui/src/query/display_query.cpp
@@ -100,6 +100,7 @@ void DisplayLayoutSetQuery::setClearFillmode(bool v) { WW_SET(m_clear_fillmode, 
 void DisplayLayoutSetQuery::setClearLocation(bool v) { WW_SET(m_clear_location, v); }
 void DisplayLayoutSetQuery::setClearAlign(bool v) { WW_SET(m_clear_align, v); }
 void DisplayLayoutSetQuery::setClearRotation(bool v) { WW_SET(m_clear_rotation, v); }
+void DisplayLayoutSetQuery::setLocation(int v) { WW_SET(m_location, v); }
 #undef WW_SET
 
 void DisplayLayoutSetQuery::reload() {
@@ -125,6 +126,7 @@ void DisplayLayoutSetQuery::reload() {
     inner.setClearLocation(m_clear_location);
     inner.setClearAlign(m_clear_align);
     inner.setClearRotation(m_clear_rotation);
+    inner.setLocation(static_cast<proto::LayoutLocation>(m_location));
 
     auto req = proto::Request {};
     req.setDisplayLayoutSet(std::move(inner));

--- a/ui/src/query/display_query.cppm
+++ b/ui/src/query/display_query.cppm
@@ -64,6 +64,8 @@ export class DisplayLayoutSetQuery
     Q_PROPERTY(bool clearAlign READ clearAlign WRITE setClearAlign NOTIFY paramsChanged FINAL)
     Q_PROPERTY(
         bool clearRotation READ clearRotation WRITE setClearRotation NOTIFY paramsChanged FINAL)
+    /// 0 = desktop (default), 1 = lock screen. (same proto::LayoutLocation)
+    Q_PROPERTY(int location READ location WRITE setLocation NOTIFY paramsChanged FINAL)
 
 public:
     DisplayLayoutSetQuery(QObject* parent = nullptr);
@@ -98,6 +100,8 @@ public:
     void setClearAlign(bool v);
     auto clearRotation() const -> bool { return m_clear_rotation; }
     void setClearRotation(bool v);
+    auto location() const -> int { return m_location; }
+    void setLocation(int v);
 
     void reload() override;
 
@@ -106,6 +110,7 @@ public:
 private:
     QString m_name;
     quint64 m_display_id { 0 };
+    int     m_location { 0 };
     bool    m_fillmode_set { false };
     int     m_fillmode { 0 };
     bool    m_location_set { false };

--- a/ui/src/query/display_query.cppm
+++ b/ui/src/query/display_query.cppm
@@ -154,4 +154,34 @@ private:
     bool    m_clear { false };
 };
 
+export class DisplayLockWallpaperSetQuery
+    : public Query,
+      public QueryExtra<control::v1::Response, DisplayLockWallpaperSetQuery> {
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY paramsChanged FINAL)
+    Q_PROPERTY(quint64 displayId READ displayId WRITE setDisplayId NOTIFY paramsChanged FINAL)
+    Q_PROPERTY(QString wallpaperId READ wallpaperId WRITE setWallpaperId NOTIFY paramsChanged FINAL)
+
+public:
+    DisplayLockWallpaperSetQuery(QObject* parent = nullptr);
+
+    auto name() const -> const QString& { return m_name; }
+    void setName(const QString& v);
+    auto displayId() const -> quint64 { return m_display_id; }
+    void setDisplayId(quint64 v);
+    auto wallpaperId() const -> const QString& { return m_wallpaper_id; }
+    void setWallpaperId(const QString& v);
+
+    void reload() override;
+
+    Q_SIGNAL void paramsChanged();
+
+private:
+    QString m_name;
+    quint64 m_display_id { 0 };
+    QString m_wallpaper_id;
+};
+
 } // namespace waywallen

--- a/ui/src/query/display_query.cppm
+++ b/ui/src/query/display_query.cppm
@@ -160,17 +160,15 @@ export class DisplayLockWallpaperSetQuery
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(QString name READ name WRITE setName NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(quint64 displayId READ displayId WRITE setDisplayId NOTIFY paramsChanged FINAL)
+    Q_PROPERTY(
+        QVariantList displayIds READ displayIds WRITE setDisplayIds NOTIFY paramsChanged FINAL)
     Q_PROPERTY(QString wallpaperId READ wallpaperId WRITE setWallpaperId NOTIFY paramsChanged FINAL)
 
 public:
     DisplayLockWallpaperSetQuery(QObject* parent = nullptr);
 
-    auto name() const -> const QString& { return m_name; }
-    void setName(const QString& v);
-    auto displayId() const -> quint64 { return m_display_id; }
-    void setDisplayId(quint64 v);
+    auto displayIds() const -> const QVariantList& { return m_display_ids; }
+    void setDisplayIds(const QVariantList& v);
     auto wallpaperId() const -> const QString& { return m_wallpaper_id; }
     void setWallpaperId(const QString& v);
 
@@ -179,9 +177,8 @@ public:
     Q_SIGNAL void paramsChanged();
 
 private:
-    QString m_name;
-    quint64 m_display_id { 0 };
-    QString m_wallpaper_id;
+    QVariantList m_display_ids;
+    QString      m_wallpaper_id;
 };
 
 } // namespace waywallen

--- a/ui/src/query/wallpaper_query.cpp
+++ b/ui/src/query/wallpaper_query.cpp
@@ -434,60 +434,6 @@ void WallpaperPropertySetQuery::reload() {
 }
 
 // ---------------------------------------------------------------------------
-// WallpaperLayoutSetQuery
-// ---------------------------------------------------------------------------
-
-WallpaperLayoutSetQuery::WallpaperLayoutSetQuery(QObject* parent): Query(parent) {}
-
-#define WW_SET(field, val)          \
-    do {                            \
-        if (this->field != val) {   \
-            this->field = val;      \
-            Q_EMIT paramsChanged(); \
-        }                           \
-    } while (0)
-
-void WallpaperLayoutSetQuery::setWallpaperId(const QString& v) { WW_SET(m_wallpaper_id, v); }
-void WallpaperLayoutSetQuery::setClear(bool v) { WW_SET(m_clear, v); }
-void WallpaperLayoutSetQuery::setFillmode(int v) { WW_SET(m_fillmode, v); }
-void WallpaperLayoutSetQuery::setLocationX(int v) { WW_SET(m_location_x, v); }
-void WallpaperLayoutSetQuery::setLocationY(int v) { WW_SET(m_location_y, v); }
-void WallpaperLayoutSetQuery::setRotation(int v) { WW_SET(m_rotation, v); }
-#undef WW_SET
-
-void WallpaperLayoutSetQuery::reload() {
-    if (m_wallpaper_id.isEmpty()) return;
-    setStatus(Status::Querying);
-    auto backend = App::instance()->backend();
-
-    auto inner = proto::WallpaperLayoutSetRequest {};
-    inner.setWallpaperId(m_wallpaper_id);
-    inner.setClear(m_clear);
-    if (! m_clear) {
-        auto layout = proto::LayoutPrefs {};
-        layout.setFillmode(static_cast<proto::FillMode>(m_fillmode));
-        layout.setLocationX(static_cast<quint32>(std::clamp(m_location_x, 0, 100)));
-        layout.setLocationY(static_cast<quint32>(std::clamp(m_location_y, 0, 100)));
-        layout.setLocationSet(true);
-        layout.setRotation(static_cast<proto::Rotation>(m_rotation));
-        inner.setLayout(std::move(layout));
-    }
-
-    auto req = proto::Request {};
-    req.setWallpaperLayoutSet(std::move(inner));
-
-    auto self = QWatcher { this };
-    spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
-        auto result = co_await backend->send(std::move(req));
-        co_await asio::post(asio::bind_executor(QAsyncResult::get_executor(), use_task));
-        if (! self) co_return;
-        self->inspect_set(result, [](const proto::Response&) {
-        });
-        co_return;
-    });
-}
-
-// ---------------------------------------------------------------------------
 // WallpaperApplyQuery
 // ---------------------------------------------------------------------------
 

--- a/ui/src/query/wallpaper_query.cppm
+++ b/ui/src/query/wallpaper_query.cppm
@@ -218,48 +218,6 @@ private:
     bool    m_reset { false };
 };
 
-export class WallpaperLayoutSetQuery
-    : public Query,
-      public QueryExtra<control::v1::Response, WallpaperLayoutSetQuery> {
-    Q_OBJECT
-    QML_ELEMENT
-
-    Q_PROPERTY(QString wallpaperId READ wallpaperId WRITE setWallpaperId NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(bool clear READ clear WRITE setClear NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(int fillmode READ fillmode WRITE setFillmode NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(int locationX READ locationX WRITE setLocationX NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(int locationY READ locationY WRITE setLocationY NOTIFY paramsChanged FINAL)
-    Q_PROPERTY(int rotation READ rotation WRITE setRotation NOTIFY paramsChanged FINAL)
-
-public:
-    WallpaperLayoutSetQuery(QObject* parent = nullptr);
-
-    auto wallpaperId() const -> const QString& { return m_wallpaper_id; }
-    void setWallpaperId(const QString& v);
-    auto clear() const -> bool { return m_clear; }
-    void setClear(bool v);
-    auto fillmode() const -> int { return m_fillmode; }
-    void setFillmode(int v);
-    auto locationX() const -> int { return m_location_x; }
-    void setLocationX(int v);
-    auto locationY() const -> int { return m_location_y; }
-    void setLocationY(int v);
-    auto rotation() const -> int { return m_rotation; }
-    void setRotation(int v);
-
-    void reload() override;
-
-    Q_SIGNAL void paramsChanged();
-
-private:
-    QString m_wallpaper_id;
-    bool    m_clear { false };
-    int     m_fillmode { 3 };
-    int     m_location_x { 50 };
-    int     m_location_y { 50 };
-    int     m_rotation { 1 };
-};
-
 export class WallpaperApplyQuery : public Query,
                                    public QueryExtra<control::v1::Response, WallpaperApplyQuery> {
     Q_OBJECT


### PR DESCRIPTION
Closes #138 and addresses UX issues that arise with allowing lock screens. Removes the per-wallpaper layout properties and the display override mechanisms in favor of having it set per display/location. Also addresses some renderer delays and reduces the amount of time a black screen is shown when the screen is just locked.