### PR TITLE
Fix building and running from a fresh source checkout

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,6 +12,7 @@ End-to-end build instructions for developers.
 | Vulkan SDK | ≥ 1.1 |  |
 | Qt6 | ≥ 6.10 | Quick, DBus, Protobuf |
 | ffmpeg | - |  |
+| git-lfs | - | QmlMaterial stores its icon fonts in LFS; without it the UI builds but every icon renders as a placeholder box |
 
 ## Build, install, run
 

--- a/deps.json
+++ b/deps.json
@@ -68,7 +68,7 @@
     }
   },
   {
-    "commit": "d02d9a7bfed546dfb7f87a5627b1c9e8f6fcc95a",
+    "commit": "1eadfcb9fc9d2d7b61d0ff2ec7a9f6982863336e",
     "dest": "build/_flatpak_deps/QExtra-src",
     "disable-shallow-clone": true,
     "type": "git",

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -142,6 +142,10 @@ void App::init() {
     // Connect to the daemon's WebSocket (no-op if port is still 0).
     d->m_backend->connectTo();
 
+    // Resolve the installed QML modules relative to the executable
+    // (bin/ ←→ lib/qt6/qml) so spawns that don't inherit
+    // QML_IMPORT_PATH — tray "Open UI", desktop entries — still work.
+    engine->addImportPath(QGuiApplication::applicationDirPath() + u"/../lib/qt6/qml"_s);
     engine->addImportPath(u"qrc:/"_s);
     // Load the main window from the QML module.
     engine->loadFromModule("waywallen.ui", "Window");

--- a/ui/src/query/plugin_action_query.cpp
+++ b/ui/src/query/plugin_action_query.cpp
@@ -41,7 +41,7 @@ void PluginActionQuery::reload() {
     auto self = QWatcher { this };
     spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
         auto result = co_await backend->send(std::move(req));
-        co_await asio::post(asio::bind_executor(QAsyncResult::get_executor(), use_task));
+        if (! co_await QAsyncResult::qexecutor()) co_return;
         if (! self) co_return;
         self->inspect_set(result, [](const proto::Response&) {});
         co_return;

--- a/ui/src/query/steam_login_query.cpp
+++ b/ui/src/query/steam_login_query.cpp
@@ -24,7 +24,7 @@ void SteamLoginStartQuery::reload() {
     auto self = QWatcher { this };
     spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
         auto result = co_await backend->send(std::move(req));
-        co_await asio::post(asio::bind_executor(QAsyncResult::get_executor(), use_task));
+        if (! co_await QAsyncResult::qexecutor()) co_return;
         if (! self) co_return;
         self->inspect_set(result, [](const proto::Response&) {});
         co_return;
@@ -43,7 +43,7 @@ void SteamLoginCancelQuery::reload() {
     auto self = QWatcher { this };
     spawn([self, backend, req = std::move(req)]() mutable -> task<void> {
         auto result = co_await backend->send(std::move(req));
-        co_await asio::post(asio::bind_executor(QAsyncResult::get_executor(), use_task));
+        if (! co_await QAsyncResult::qexecutor()) co_return;
         if (! self) co_return;
         self->inspect_set(result, [](const proto::Response&) {});
         co_return;


### PR DESCRIPTION
# Branch

contrib/source-build-fixes

# Title

Fix building and running from a fresh source checkout

# Body

First of the smaller PRs split out of #143. Three unrelated-looking fixes with the same theme: a fresh clone built by the book doesn't work right now.

- The pinned QExtra still imports the asio module, which was removed in its rstd migration, so configure + build fails. Bumped to 1eadfcb, the newest revision compatible with the rstd pinned here — QExtra HEAD already tracks a newer rstd and doesn't compile against this one. (The wavsen bump from #143 is gone — main already has it.)
- With QExtra synced, steam_login_query and plugin_action_query stop compiling: they still await through asio::post / bind_executor from before the async runtime migration. Moved them to the qexecutor() pattern the other queries use.
- BUILD.md now lists git-lfs. QmlMaterial keeps its icon fonts in LFS, and without git-lfs the build succeeds but embeds the 131-byte pointer files as fonts, so every icon renders as a box. Took me a while to figure that one out.
- waywallen-ui only found its QML module when QML_IMPORT_PATH pointed at the install prefix, so tray "Open UI" from an autostarted daemon (or launching from a desktop entry) aborted with "main window must exist". It now also resolves bin/../lib/qt6/qml relative to the executable.
