### PR TITLE
source: surface scan failures instead of reporting success

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -1670,12 +1670,16 @@ async fn refresh_sources_inner(app: &Arc<AppState>) -> Result<usize> {
     // Hold the Lua VM lock only during the scan; wallpaper reads hit the DB
     // and do not wait behind this section.
     let handle = tokio::runtime::Handle::current();
-    let snapshot: Vec<WallpaperEntry> = tokio::task::spawn_blocking(move || {
-        handle.block_on(source_mgr.scan_all(&libs_for_scan))?;
-        Ok::<_, anyhow::Error>(source_mgr.list())
-    })
-    .await
-    .map_err(|e| Error::Internal(anyhow!("source scan join: {e}")))??;
+    // A failing source plugin must not discard what the others found, so the
+    // scan error is carried alongside the snapshot and only surfaced once the
+    // successful entries have been synced.
+    let (snapshot, scan_error): (Vec<WallpaperEntry>, Option<Error>) =
+        tokio::task::spawn_blocking(move || {
+            let scan_error = handle.block_on(source_mgr.scan_all(&libs_for_scan)).err();
+            (source_mgr.list(), scan_error)
+        })
+        .await
+        .map_err(|e| Error::Internal(anyhow!("source scan join: {e}")))?;
 
     let plugins = match app.source_manager.plugins() {
         Ok(p) => p,
@@ -1752,5 +1756,8 @@ async fn refresh_sources_inner(app: &Arc<AppState>) -> Result<usize> {
         },
     );
 
+    if let Some(e) = scan_error {
+        return Err(e);
+    }
     Ok(count)
 }

--- a/src/plugin/source_manager.rs
+++ b/src/plugin/source_manager.rs
@@ -1836,6 +1836,11 @@ impl LuaPluginRuntime {
             .filter_map(|(name, info)| info.capabilities.source.is_some().then(|| name.clone()))
             .collect();
         plugin_names.sort();
+        // Every plugin is scanned even if an earlier one fails, so one broken
+        // source does not hide the wallpapers the others found. The failures
+        // are still reported, otherwise a failed scan is indistinguishable from
+        // a scan that legitimately found nothing.
+        let mut failures: Vec<String> = Vec::new();
         for name in &plugin_names {
             let libs = libs_by_plugin
                 .get(name)
@@ -1843,7 +1848,14 @@ impl LuaPluginRuntime {
                 .unwrap_or(&[]);
             if let Err(e) = self.scan_plugin(name, libs).await {
                 log::warn!("scan plugin {name} failed: {e}");
+                failures.push(format!("{name}: {e:#}"));
             }
+        }
+        if !failures.is_empty() {
+            return Err(Error::Internal(anyhow!(
+                "source scan failed for {}",
+                failures.join("; ")
+            )));
         }
         Ok(())
     }
@@ -3658,10 +3670,18 @@ impl LuaPluginRegistry {
         });
         let results = futures_util::future::join_all(scans).await;
         let mut entries = Vec::new();
+        // The catalog is still replaced with whatever the healthy plugins
+        // returned, so one broken source does not hide the rest. The failures
+        // are reported afterwards: a scan that failed must not be presented as
+        // a scan that simply found nothing.
+        let mut failures: Vec<String> = Vec::new();
         for result in results {
             match result {
                 Ok(mut plugin_entries) => entries.append(&mut plugin_entries),
-                Err(e) => log::warn!("scan Lua plugin failed: {e}"),
+                Err(e) => {
+                    log::warn!("scan Lua plugin failed: {e}");
+                    failures.push(format!("{e:#}"));
+                }
             }
         }
         entries.sort_by(|a, b| {
@@ -3673,6 +3693,12 @@ impl LuaPluginRegistry {
             .write()
             .expect("source catalog lock poisoned")
             .replace(entries);
+        if !failures.is_empty() {
+            return Err(Error::Internal(anyhow!(
+                "source scan failed: {}",
+                failures.join("; ")
+            )));
+        }
         Ok(())
     }
 
@@ -4435,6 +4461,46 @@ return M
             .load_plugin(&plugin_path, "org.grouped", "1", ENTRY_VERSION_V3)
             .unwrap();
         block_value(async { manager.scan_all(&HashMap::new()).await }).unwrap();
+    }
+
+    #[test]
+    fn scan_all_reports_a_failing_plugin_instead_of_reporting_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_path = dir.path().join("failing_source.lua");
+        let mut f = std::fs::File::create(&plugin_path).unwrap();
+        write!(
+            f,
+            r#"
+local M = {{}}
+function M.info()
+    return {{
+        name = "failing",
+        capabilities = {{
+            source = {{ types = {{"image"}}, scan = true }},
+        }},
+    }}
+end
+M.source = {{}}
+function M.source.scan(ctx)
+    error("library root is unreadable")
+end
+return M
+"#
+        )
+        .unwrap();
+
+        let mgr = SourceManager::new().unwrap();
+        mgr.load_plugin(&plugin_path, "failing.plugin", "1.0", ENTRY_VERSION)
+            .unwrap();
+
+        let result = block_value(async { mgr.scan_all(&HashMap::new()).await });
+
+        let err = result.expect_err("a failing source scan must not report success");
+        assert!(
+            err.to_string().contains("failing"),
+            "error should name the plugin that failed, got: {err}"
+        );
+        assert!(mgr.list().is_empty());
     }
 
     #[test]


### PR DESCRIPTION

A source plugin whose `scan(ctx)` fails is only logged at warn level: both
`scan_all` layers swallow the error and return `Ok`, so `refresh_sources`
publishes `SyncFinished` and the UI shows "Scanned 0 wallpapers" as a
successful sync. A scan that failed is then indistinguishable from one that
legitimately found nothing.

That is how waywallen/open-wallpaper-engine#45 went unnoticed: a mis-registered
Steam library path produced an empty catalogue that looked like success. (I have
a companion PR against open-wallpaper-engine for the path handling itself; this
one is about the silence.)

Both layers now collect their per-plugin failures and return them:

- the inner `scan_all` keeps scanning every plugin, then reports what failed;
- the outer `scan_all` still replaces the catalogue with whatever the healthy
  plugins returned before reporting.

`refresh_sources_inner` carries the error alongside the snapshot so the
successful entries are still synced to the database, and surfaces it at the end.
One broken source therefore does not hide the wallpapers the others found, and
the existing `SyncFailed` path fires instead of a false `SyncFinished`.

### Testing

Adds `scan_all_reports_a_failing_plugin_instead_of_reporting_success`, which
loads a plugin whose `scan` raises and asserts the error names it. Full suite:
320 passed, 0 failed; `cargo fmt --check` clean.

Worth flagging while I was in there: there is no diagnostic channel for Lua
sources at all — `ctx` has `log` but no `ctx.warn`/`ctx.error`, so a plugin that
detects a bad library path can only write to the daemon log. If you would like
that as a follow-up, I am happy to put it together.
