### PR TITLE
docs: update desktop integration table (niri auto pause, Wayfire)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ It started life as a Wallpaper Engine plugin for KDE.
 | **KDE Plasma** | [waywallen-display](https://github.com/waywallen/waywallen-display/) | ✅ | ✅ |
 | **GNOME** | [waywallen-display](https://github.com/waywallen/waywallen-display/) | ✅ | ✅ |
 | **Hyprland** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ✅ |
-| **Niri** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ❌ |
+| **Niri** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ✅ |
+| **Wayfire** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ✅ |
 | **Sway** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ❌ |
 | **COSMIC** | [waywallen-display/layer_shell](https://github.com/waywallen/waywallen-display/tree/main/src/bin/layer_shell) | ✅ | ❌ |
 


### PR DESCRIPTION
The table still lists Niri as having no auto pause, and does not mention Wayfire at all. Both have window-state watchers in `waywallen-display`:

- `src/bin/layer_shell/watcher/niri.rs`, spawned from `main.rs` — landed in v0.2.7 via waywallen/waywallen-display#19.
- `src/bin/layer_shell/watcher/wayfire.rs`, spawned from the same place — landed via waywallen/waywallen-display#26.

Sway and COSMIC still have no watcher, so their ❌ stays.

One caveat I did not encode in the table, since it only has room for a tick: the Niri watcher currently never sets `WAYWALLEN_WIN_HAS_MAXIMIZED` (the branch is commented out), and derives `WAYWALLEN_WIN_HAS_FULLSCREEN` by comparing the window size against the output size, with a TODO pointing at niri-wm/niri#2836. So "✅" there means the feature is wired up and reacting, not that every bit is exact. Happy to word it differently — a footnote, or "✅*" — if you would rather the table stay strict.

I have not run Niri or Wayfire myself; this is from reading the watchers and their spawn sites, not from testing.