### PR TITLE
source: name Wallhaven wallpapers after their uploader

### DIFF
--- a/plugins/org.waywallen.wallhaven/wallhaven/map.lua
+++ b/plugins/org.waywallen.wallhaven/wallhaven/map.lua
@@ -24,6 +24,16 @@ local function rating(purity)
     return "Everyone"
 end
 
+-- Only /w/<id> carries an uploader; the search listing has no such field, so a
+-- name can be had for a wallpaper that has been opened and for no other.
+local function uploader_name(detail)
+    local uploader = detail.uploader
+    if type(uploader) ~= "table" then
+        return ""
+    end
+    return uploader.username or ""
+end
+
 local function title(item)
     if item.id and item.id ~= "" then
         return "Wallhaven " .. item.id
@@ -49,6 +59,7 @@ end
 function M.details(detail)
     local description = detail.source or detail.url or ""
     return {
+        author = uploader_name(detail),
         description = description,
         size = tostring(detail.file_size or ""),
         width = detail.dimension_x,

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -875,6 +875,9 @@ message RemoteDetailsResponse {
   uint32 width = 5;
   uint32 height = 6;
   string web_url = 7;
+  // Empty unless the source knows an author it could not already put on the
+  // RemoteItem, e.g. one only its per-item endpoint reports.
+  string author = 8;
 }
 
 enum RemoteDownloadState {

--- a/src/plugin/source_manager.rs
+++ b/src/plugin/source_manager.rs
@@ -323,6 +323,7 @@ pub struct DiscoverItem {
 /// Detail blob returned by a plugin's `discover.details(ctx, id)`.
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DiscoverDetails {
+    pub author: String,
     pub description: String,
     pub size: String,
     pub width: Option<u32>,
@@ -2710,6 +2711,7 @@ impl LuaPluginRuntime {
             })?;
 
         let details = DiscoverDetails {
+            author: Self::optional_string(&result, "author", "module.discover.details result")?,
             description: Self::require_string(
                 &result,
                 "description",
@@ -4610,6 +4612,7 @@ function M.discover.search(ctx, params)
 end
 function M.discover.details(ctx, id)
     return {
+        author = "Imported Author",
         description = names.name(),
         size = "42",
         width = 10,
@@ -4660,6 +4663,7 @@ return M
         assert_eq!(detail.width, Some(10));
         assert_eq!(detail.height, Some(20));
         assert_eq!(detail.web_url, "https://example.invalid/item/abc");
+        assert_eq!(detail.author, "Imported Author");
     }
 
     #[test]
@@ -4879,11 +4883,20 @@ return M
         let details: LuaFunction = map.get("details").unwrap();
         let detail = runtime.lua.create_table().unwrap();
         detail.set("url", "https://wallhaven.cc/w/abc123").unwrap();
-        let mapped: LuaTable = details.call(detail).unwrap();
+        let mapped: LuaTable = details.call(detail.clone()).unwrap();
         assert_eq!(
             mapped.get::<String>("web_url").unwrap(),
             "https://wallhaven.cc/w/abc123"
         );
+        // A wallpaper Wallhaven reports no uploader for keeps the empty author
+        // the listing has always produced.
+        assert_eq!(mapped.get::<String>("author").unwrap(), "");
+
+        let uploader = runtime.lua.create_table().unwrap();
+        uploader.set("username", "Qtn").unwrap();
+        detail.set("uploader", uploader).unwrap();
+        let mapped: LuaTable = details.call(detail).unwrap();
+        assert_eq!(mapped.get::<String>("author").unwrap(), "Qtn");
     }
 
     #[test]

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -2376,6 +2376,7 @@ async fn dispatch_inner(
                         width: 0,
                         height: 0,
                         web_url: String::new(),
+                        author: String::new(),
                     }));
                 }
             };
@@ -2389,6 +2390,7 @@ async fn dispatch_inner(
                     width: details.width.unwrap_or(0),
                     height: details.height.unwrap_or(0),
                     web_url: details.web_url,
+                    author: details.author,
                 }),
                 Err(e) => Res::RemoteDetails(pb::RemoteDetailsResponse {
                     description: String::new(),
@@ -2398,6 +2400,7 @@ async fn dispatch_inner(
                     width: 0,
                     height: 0,
                     web_url: String::new(),
+                    author: String::new(),
                 }),
             }
         }

--- a/ui/qml/page/RemoteDetailPanel.qml
+++ b/ui/qml/page/RemoteDetailPanel.qml
@@ -9,6 +9,13 @@ Item {
 
     property var item: null
     property var details: null
+
+    // A source that cannot name an item while listing it may still name it once
+    // the item is opened, so let a detail lookup fill in what the row lacks.
+    readonly property string authorName: {
+        const own = String(root.item?.author ?? "");
+        return own.length > 0 ? own : String(root.details?.author ?? "");
+    }
     property int remoteCapability: 0
     property string remoteHint: ""
     property int downloadState: 0
@@ -135,8 +142,8 @@ Item {
 
                 MD.Text {
                     Layout.fillWidth: true
-                    visible: String(root.item?.author ?? "").length > 0
-                    text: qsTr("by %1").arg(root.item?.author ?? "")
+                    visible: root.authorName.length > 0
+                    text: qsTr("by %1").arg(root.authorName)
                     typescale: MD.Token.typescale.body_medium
                     color: MD.Token.color.on_surface_variant
                     wrapMode: Text.WordWrap

--- a/ui/qml/page/RemoteInfoPage.qml
+++ b/ui/qml/page/RemoteInfoPage.qml
@@ -15,6 +15,13 @@ MD.Page {
     property int remoteCapability: 0
     property string remoteHint: ""
 
+    // A source that cannot name an item while listing it may still name it once
+    // the item is opened, so let a detail lookup fill in what the row lacks.
+    readonly property string authorName: {
+        const own = String(root.item?.author ?? "");
+        return own.length > 0 ? own : String(root.details?.author ?? "");
+    }
+
     readonly property string formattedSize: formatSize(details?.size)
     readonly property string tagsText: formatList(details?.tags)
 
@@ -139,12 +146,12 @@ MD.Page {
             }
 
             InfoLabel {
-                visible: root.hasText(root.item?.author)
+                visible: root.authorName.length > 0
                 label: "Author"
             }
             InfoValue {
-                visible: root.hasText(root.item?.author)
-                text: root.value(root.item?.author)
+                visible: root.authorName.length > 0
+                text: root.authorName
             }
 
             InfoLabel {

--- a/ui/src/query/remote_query.cpp
+++ b/ui/src/query/remote_query.cpp
@@ -320,6 +320,7 @@ void RemoteDetailsQuery::setItemId(const QString& v) {
         Q_EMIT itemIdChanged();
     }
 }
+auto RemoteDetailsQuery::author() const -> const QString& { return m_author; }
 auto RemoteDetailsQuery::description() const -> const QString& { return m_description; }
 auto RemoteDetailsQuery::size() const -> const QString& { return m_size; }
 auto RemoteDetailsQuery::width() const -> int { return m_width; }
@@ -328,6 +329,7 @@ auto RemoteDetailsQuery::tags() const -> const QStringList& { return m_tags; }
 auto RemoteDetailsQuery::webUrl() const -> const QString& { return m_web_url; }
 
 void RemoteDetailsQuery::reload() {
+    m_author.clear();
     m_description.clear();
     m_size.clear();
     m_width  = 0;
@@ -353,6 +355,7 @@ void RemoteDetailsQuery::reload() {
 
         self->inspect_set(result, [self](const proto::Response& rsp) {
             const auto& dr      = rsp.remoteDetails();
+            self->m_author      = dr.author();
             self->m_description = dr.description();
             self->m_size        = dr.size();
             self->m_width       = static_cast<int>(dr.width());

--- a/ui/src/query/remote_query.cppm
+++ b/ui/src/query/remote_query.cppm
@@ -105,6 +105,7 @@ export class RemoteDetailsQuery : public Query,
 
     Q_PROPERTY(QString sourceId READ sourceId WRITE setSourceId NOTIFY sourceIdChanged FINAL)
     Q_PROPERTY(QString itemId READ itemId WRITE setItemId NOTIFY itemIdChanged FINAL)
+    Q_PROPERTY(QString author READ author NOTIFY loaded FINAL)
     Q_PROPERTY(QString description READ description NOTIFY loaded FINAL)
     Q_PROPERTY(QString size READ size NOTIFY loaded FINAL)
     Q_PROPERTY(int width READ width NOTIFY loaded FINAL)
@@ -120,6 +121,7 @@ public:
 
     auto itemId() const -> const QString&;
     void setItemId(const QString&);
+    auto author() const -> const QString&;
     auto description() const -> const QString&;
     auto size() const -> const QString&;
     auto width() const -> int;
@@ -136,6 +138,7 @@ public:
 private:
     QString     m_source_id;
     QString     m_item_id;
+    QString     m_author;
     QString     m_description;
     QString     m_size;
     int         m_width { 0 };


### PR DESCRIPTION
Wallhaven items have always been sent to the UI with an empty `author`, so the `by %1`
line in the detail panel and the `Author` row in the info page never had anything to
show. This fills them in.

Same idea as waywallen/open-wallpaper-engine#87, which you merged for the Workshop
source; only the delivery path differs, and that difference is the whole substance of
this patch.

## Where the name comes from

`GET /api/v1/w/<id>` reports an `uploader` object, and the plugin **already makes that
request** — it is what fills the detail panel. So the name costs nothing: no new request,
no new endpoint, no key.

## Why the grid cards stay unnamed

`GET /api/v1/search` does not carry an uploader at all. Its items have 18 fields and the
author is not among them, so naming a card would mean one extra round trip *per item on
the page*. In #87 that cost was real but bounded, and I capped it with a time budget and
a per-author cache. Here it would be higher for less: Wallhaven has no bulk lookup
either, and every id on the page would need its own request before the grid could settle.

So the author arrives with the details rather than with the row. In practice that is the
only place it was ever rendered anyway — `RemoteCard` does not draw an author — so
nothing looks emptier than it did before.

## What that needed

`RemoteDetailsResponse` had no room for an author, so it gains one (field 8), plumbed
through `DiscoverDetails` and `RemoteDetailsQuery`. `RemoteDetailPanel` and
`RemoteInfoPage` prefer the item's own author and fall back to the details' one, so
sources that can name an item while listing it — the Workshop source among them — behave
exactly as before.

## When it fails

Nothing new happens. A details call that fails already leaves the panel empty; the author
is simply one more field that stays empty with it. A wallpaper Wallhaven reports no
uploader for maps to `""`, same as today.

## How it was tested

* `cargo test --lib source_manager` — extended two tests: the details contract carries an
  author end to end, and the Wallhaven mapper yields `""` for a wallpaper with no
  uploader and the username for one with an uploader.
* Full `cmake --build` of daemon and UI, then `cmake --install` into a throwaway prefix.
* End to end against a live daemon on throwaway `XDG_DATA_HOME`/`XDG_CONFIG_HOME`/
  `XDG_CACHE_HOME` and a private session bus, driving the control plane directly:
  a trending search returned 24 items with empty authors, and `RemoteDetails` on the
  first three answered `Qtn`, `Mcam666` and `Pc7` — which is what wallhaven.cc reports
  for `zpdogo`, `7jeozo` and `gwm2z3`.
* Same daemon with the UI: Discover → Wallhaven → opened `zpdogo`; the panel reads
  `by Qtn` and the info page's `Author` row reads `Qtn`. Grid cards unchanged.
* Failure path on the same setup: `RemoteDetails` for an id Wallhaven 404s on returned
  the same error it did before, an empty author, and left the daemon healthy.
* `scripts/format.sh --check` passes.

## Not included

The avatar. The same `uploader` object carries it in four sizes, and it has nowhere to go
— that is #169, kept separate. A "more from this uploader" link is a separate thought too.
