### PR TITLE
ui: mark remaining user-facing strings for translation

### DIFF
--- a/ui/qml/Window.qml
+++ b/ui/qml/Window.qml
@@ -48,10 +48,10 @@ MD.ApplicationWindow {
     readonly property bool isCompact: MD.MProp.size.isCompact
 
     readonly property var pageModel: [
-        { icon: MD.Token.icon.wallpaper, name: "Wallpapers" },
-        { icon: MD.Token.icon.explore, name: "Discover" },
-        { icon: MD.Token.icon.monitor, name: "Displays" },
-        { icon: MD.Token.icon.monitor_heart, name: "Status" }
+        { icon: MD.Token.icon.wallpaper, name: qsTr("Wallpapers") },
+        { icon: MD.Token.icon.explore, name: qsTr("Discover") },
+        { icon: MD.Token.icon.monitor, name: qsTr("Displays") },
+        { icon: MD.Token.icon.monitor_heart, name: qsTr("Status") }
     ]
 
 
@@ -102,7 +102,7 @@ MD.ApplicationWindow {
         target: W.Notify
         function onLibrariesAdded(paths) {
             const n = paths.length;
-            W.Action.toast(n === 1 ? "Library added" : (n + " libraries added"));
+            W.Action.toast(qsTr("%n library(s) added", "", n));
         }
         function onDisplayConnectionFailed(clientName, clientProtocolVersion, errorCode, reason) {
             const who = clientName.length > 0 ? clientName : qsTr("Display client");
@@ -210,7 +210,7 @@ MD.ApplicationWindow {
                                 expand: m_rail.useLarge
                                 checked: false
                                 icon.name: MD.Token.icon.extension
-                                text: "Plugins"
+                                text: qsTr("Plugins")
                                 onClicked: MD.Util.showPopup('waywallen.ui/PagePopup', {
                                     source: 'waywallen.ui/PluginManagePage'
                                 }, win)
@@ -221,7 +221,7 @@ MD.ApplicationWindow {
                                 expand: m_rail.useLarge
                                 checked: false
                                 icon.name: MD.Token.icon.settings
-                                text: "Settings"
+                                text: qsTr("Settings")
                                 onClicked: MD.Util.showPopup('waywallen.ui/PagePopup', {
                                     source: 'waywallen.ui/SettingsPage'
                                 }, win)
@@ -233,7 +233,7 @@ MD.ApplicationWindow {
                                 expand: true
                                 checked: false
                                 icon.name: MD.Token.icon.info
-                                text: "About"
+                                text: qsTr("About")
                                 onClicked: MD.Util.showPopup('waywallen.ui/PagePopup', {
                                     source: 'waywallen.ui/AboutPage'
                                 }, win)

--- a/ui/qml/component/settings/SettingField.qml
+++ b/ui/qml/component/settings/SettingField.qml
@@ -56,8 +56,8 @@ ColumnLayout {
     // Wire enum value → display label. Kept in sync with
     // <waywallen-bridge/resolution.h> WW_RESOLUTION_*.
     readonly property var resolutionPresets: [
-        { value: "-1", label: "Custom" },
-        { value: "0", label: "Origin" },
+        { value: "-1", label: qsTr("Custom") },
+        { value: "0", label: qsTr("Origin") },
         { value: "1", label: "720p" },
         { value: "2", label: "1080p" },
         { value: "3", label: "1440p" },
@@ -145,7 +145,7 @@ ColumnLayout {
                 id: hovered
             }
             MD.ToolTip.visible: hovered.hovered
-            MD.ToolTip.text: "Requires renderer restart"
+            MD.ToolTip.text: qsTr("Requires renderer restart")
         }
     }
 
@@ -359,7 +359,7 @@ ColumnLayout {
 
             MD.FilterChip {
                 id: autoChip
-                text: "Auto"
+                text: qsTr("Auto")
                 checked: root.value === ""
                 onClicked: root._emit("")
                 Connections {

--- a/ui/qml/dialog/DaemonNotRunDialog.qml
+++ b/ui/qml/dialog/DaemonNotRunDialog.qml
@@ -52,14 +52,14 @@ MD.Popup {
             Layout.fillWidth: true
             title: {
                 if (root.daemonStarting)
-                    return "Starting…";
+                    return qsTr("Starting…");
                 switch (W.DaemonDBusClient.status) {
                 case W.DaemonDBusClient.Disconnected:
-                    return "Daemon not running";
+                    return qsTr("Daemon not running");
                 case W.DaemonDBusClient.VersionMissing:
-                    return "Daemon too old";
+                    return qsTr("Daemon too old");
                 case W.DaemonDBusClient.VersionMismatch:
-                    return "Daemon version mismatch";
+                    return qsTr("Daemon version mismatch");
                 }
                 return "";
             }
@@ -72,14 +72,14 @@ MD.Popup {
             wrapMode: Text.WordWrap
             text: {
                 if (root.daemonStarting)
-                    return "waywallen is initializing core services. This usually takes a few seconds.";
+                    return qsTr("waywallen is initializing core services. This usually takes a few seconds.");
                 switch (W.DaemonDBusClient.status) {
                 case W.DaemonDBusClient.Disconnected:
-                    return "The waywallen daemon is not on the session bus.";
+                    return qsTr("The waywallen daemon is not on the session bus.");
                 case W.DaemonDBusClient.VersionMissing:
-                    return `Daemon is online but does not advertise a version.`;
+                    return qsTr("Daemon is online but does not advertise a version.");
                 case W.DaemonDBusClient.VersionMismatch:
-                    return `Daemon version ${W.DaemonDBusClient.daemonVersion} + is incompatible.`;
+                    return qsTr("Daemon version %1 + is incompatible.").arg(W.DaemonDBusClient.daemonVersion);
                 }
                 return "";
             }
@@ -125,7 +125,7 @@ MD.Popup {
                 }
 
                 trailing: MD.BusyButton {
-                    text: "Kill"
+                    text: qsTr("Kill")
                     mdState.type: MD.Enum.BtText
                     busy: m_t.running
                     onClicked: {
@@ -146,13 +146,13 @@ MD.Popup {
             Layout.fillWidth: true
 
             MD.Button {
-                text: "Exit"
+                text: qsTr("Exit")
                 mdState.type: MD.Enum.BtText
                 T.DialogButtonBox.buttonRole: T.DialogButtonBox.RejectRole
                 onClicked: Qt.quit()
             }
             MD.Button {
-                text: "Restart"
+                text: qsTr("Restart")
                 mdState.type: MD.Enum.BtText
                 T.DialogButtonBox.buttonRole: T.DialogButtonBox.AcceptRole
                 visible: !root.daemonStarting

--- a/ui/qml/page/AboutPage.qml
+++ b/ui/qml/page/AboutPage.qml
@@ -30,7 +30,7 @@ MD.Page {
 
         MD.Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Version " + Qt.application.version
+            text: qsTr("Version %1").arg(Qt.application.version)
             typescale: MD.Token.typescale.body_medium
             color: MD.Token.color.on_surface_variant
         }
@@ -51,7 +51,7 @@ MD.Page {
 
         MD.Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Wallpaper Manager for Linux"
+            text: qsTr("Wallpaper Manager for Linux")
             typescale: MD.Token.typescale.body_large
             color: MD.Token.color.on_surface
             horizontalAlignment: Text.AlignHCenter
@@ -61,7 +61,7 @@ MD.Page {
 
         MD.Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Waywallen is a dynamic wallpaper solution for Linux desktops."
+            text: qsTr("Waywallen is a dynamic wallpaper solution for Linux desktops.")
             typescale: MD.Token.typescale.body_medium
             color: MD.Token.color.on_surface_variant
             horizontalAlignment: Text.AlignHCenter
@@ -80,19 +80,19 @@ MD.Page {
             spacing: 24
 
             MD.Button {
-                text: "GitHub"
+                text: qsTr("GitHub")
                 mdState.type: MD.Enum.BtText
                 onClicked: MD.Util.openUrlExternally("https://github.com/waywallen")
             }
 
             MD.Button {
-                text: "Issues"
+                text: qsTr("Issues")
                 mdState.type: MD.Enum.BtText
                 onClicked: MD.Util.openUrlExternally("https://github.com/waywallen/waywallen/issues")
             }
 
             MD.Button {
-                text: "Donate"
+                text: qsTr("Donate")
                 mdState.type: MD.Enum.BtText
                 onClicked: MD.Util.openUrlExternally("https://ko-fi.com/hypengw")
             }

--- a/ui/qml/page/AddLibraryPage.qml
+++ b/ui/qml/page/AddLibraryPage.qml
@@ -6,7 +6,7 @@ import waywallen.ui as W
 
 MD.Page {
     id: root
-    title: "Add Library"
+    title: qsTr("Add Library")
 
     W.SourceListQuery {
         id: sourceQuery
@@ -55,7 +55,7 @@ MD.Page {
 
     MD.FolderDialog {
         id: folderDialog
-        title: "Choose Library Folder"
+        title: qsTr("Choose Library Folder")
         onAccepted: {
             pathInput.text = selectedFolder.toString().replace(/^file:\/\//, "");
         }
@@ -74,7 +74,7 @@ MD.Page {
             Layout.margins: 16
 
             MD.Text {
-                text: "Select Source Plugin"
+                text: qsTr("Select Source Plugin")
                 typescale: MD.Token.typescale.title_small
             }
 
@@ -106,7 +106,7 @@ MD.Page {
                     Layout.fillWidth: true
                     placeholderText: (root.selectedSource && root.selectedSource.libraryLabel)
                                      ? root.selectedSource.libraryLabel
-                                     : "Library Path"
+                                     : qsTr("Library Path")
                 }
 
                 MD.IconButton {
@@ -132,7 +132,7 @@ MD.Page {
 
             MD.BusyButton {
                 Layout.fillWidth: true
-                text: "Add Library"
+                text: qsTr("Add Library")
                 busy: addQuery.querying
                 enabled: pluginGroup.selectedPlugin !== "" && pathInput.text !== ""
                 mdState.type: MD.Enum.BtFilled

--- a/ui/qml/page/DiscoverPage.qml
+++ b/ui/qml/page/DiscoverPage.qml
@@ -253,7 +253,7 @@ MD.Page {
 
     MD.Action {
         id: tweakAction
-        text: "Tweak"
+        text: qsTr("Tweak")
         icon.name: MD.Token.icon.tune
         checked: root.isSheetActive(root.discoverTweakSheet)
         onTriggered: root.toggleDiscoverTweakSheet()
@@ -262,7 +262,7 @@ MD.Page {
     MD.Action {
         id: filterAction
         icon.name: MD.Token.icon.filter_list
-        text: "Filters"
+        text: qsTr("Filters")
         enabled: m_filter_dialog.filters.length > 0
         checked: searchQuery.tags.length > 0
         onTriggered: m_filter_dialog.open()
@@ -271,7 +271,7 @@ MD.Page {
     MD.Action {
         id: refreshAction
         icon.name: MD.Token.icon.refresh
-        text: "Refresh"
+        text: qsTr("Refresh")
         enabled: searchQuery.browsingEnabled && !searchQuery.querying
         onTriggered: searchQuery.reload()
     }

--- a/ui/qml/page/DisplaysPage.qml
+++ b/ui/qml/page/DisplaysPage.qml
@@ -9,7 +9,7 @@ import waywallen.ui as W
 MD.Page {
     id: root
 
-    title: 'Displays'
+    title: qsTr('Displays')
     showHeader: MD.MProp.size.isCompact
     showBackground: false
     readonly property real displayGapPx: 80
@@ -31,7 +31,7 @@ MD.Page {
         , 3 // PRESERVE_ASPECT_CROP
         , 7  // CENTERED
     ]
-    readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
+    readonly property var kFillModeLabels: [qsTr("Stretch"), qsTr("Fit"), qsTr("Crop"), qsTr("Center")]
     function fillmodeIndex(value) {
         const i = root.kFillModeValues.indexOf(value);
         return i < 0 ? 0 : i;
@@ -259,7 +259,7 @@ MD.Page {
 
                             MD.Text {
                                 Layout.fillWidth: true
-                                text: rectItem.d.displayLabel || rectItem.d.name || ("Display " + rectItem.d.id)
+                                text: rectItem.d.displayLabel || rectItem.d.name || qsTr("Display %1").arg(rectItem.d.id)
                                 typescale: MD.Token.typescale.title_small
                                 color: rectItem.hasLink ? MD.Token.color.on_primary_container : MD.Token.color.on_surface
                                 horizontalAlignment: Text.AlignHCenter
@@ -359,7 +359,7 @@ MD.Page {
 
                         MD.Text {
                             Layout.fillWidth: true
-                            text: root.selected ? (root.selected.displayLabel || root.selected.name || ("Display " + root.selected.id)) : ""
+                            text: root.selected ? (root.selected.displayLabel || root.selected.name || qsTr("Display %1").arg(root.selected.id)) : ""
                             typescale: MD.Token.typescale.title_medium
                             color: MD.Token.color.on_surface
                             elide: Text.ElideRight
@@ -396,7 +396,7 @@ MD.Page {
                         RowLayout {
                             spacing: 8
                             MD.Text {
-                                text: "ID:"
+                                text: qsTr("ID:")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -410,7 +410,7 @@ MD.Page {
                         RowLayout {
                             spacing: 8
                             MD.Text {
-                                text: "Size:"
+                                text: qsTr("Size:")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -425,7 +425,7 @@ MD.Page {
                             visible: !!root.selected && root.selected.refreshMhz > 0
                             spacing: 8
                             MD.Text {
-                                text: "Refresh:"
+                                text: qsTr("Refresh:")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -448,7 +448,7 @@ MD.Page {
                     }
 
                     MD.Text {
-                        text: "Connected"
+                        text: qsTr("Connected")
                         typescale: MD.Token.typescale.title_small
                         color: MD.Token.color.on_surface
                     }
@@ -481,7 +481,7 @@ MD.Page {
                             if (count > 0)
                                 parts.push(Math.min(position + 1, count) + " / " + count);
                             if (remaining > 0)
-                                parts.push(Math.ceil(remaining / 60) + " min left");
+                                parts.push(qsTr("%n min left", "", Math.ceil(remaining / 60)));
                             return parts.join(" · ");
                         }
                         Layout.fillWidth: true
@@ -519,7 +519,7 @@ MD.Page {
                                         if (connectedRow.connectedId.length > 0) {
                                             return connectedRow.connectedId;
                                         }
-                                        return "Idle";
+                                        return qsTr("Idle");
                                     }
                                     typescale: MD.Token.typescale.body_medium
                                     color: connectedRow.renderer ? MD.Token.color.on_surface : MD.Token.color.on_surface_variant
@@ -567,7 +567,7 @@ MD.Page {
 
                                 MD.Text {
                                     Layout.fillWidth: true
-                                    text: "Playlist #" + connectedRow.activePlaylistId
+                                    text: qsTr("Playlist #%1").arg(connectedRow.activePlaylistId)
                                     typescale: MD.Token.typescale.body_medium
                                     color: MD.Token.color.on_surface
                                     elide: Text.ElideRight
@@ -600,14 +600,14 @@ MD.Page {
 
                         MD.Text {
                             Layout.fillWidth: true
-                            text: "Layout"
+                            text: qsTr("Layout")
                             typescale: MD.Token.typescale.title_small
                             color: MD.Token.color.on_surface
                         }
 
                         MD.AssistChip {
                             visible: !!root.selected && root.selected.layoutOverriddenByWallpaper
-                            text: "Wallpaper override"
+                            text: qsTr("Wallpaper override")
                         }
 
                         Item {
@@ -623,7 +623,7 @@ MD.Page {
                                 }
                                 icon.name: MD.Token.icon.refresh
                                 MD.ToolTip.visible: hovered
-                                MD.ToolTip.text: "Revert to global default"
+                                MD.ToolTip.text: qsTr("Revert to global default")
                                 onClicked: {
                                     if (!root.selected)
                                         return;
@@ -662,7 +662,7 @@ MD.Page {
                             spacing: 4
 
                             MD.Text {
-                                text: "Fill mode"
+                                text: qsTr("Fill mode")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -704,7 +704,7 @@ MD.Page {
                             opacity: enabled ? 1.0 : 0.4
 
                             MD.Text {
-                                text: "Horizontal"
+                                text: qsTr("Horizontal")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -731,7 +731,7 @@ MD.Page {
                             opacity: enabled ? 1.0 : 0.4
 
                             MD.Text {
-                                text: "Vertical"
+                                text: qsTr("Vertical")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -755,7 +755,7 @@ MD.Page {
                             spacing: 4
 
                             MD.Text {
-                                text: "Rotation"
+                                text: qsTr("Rotation")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }

--- a/ui/qml/page/PluginManagePage.qml
+++ b/ui/qml/page/PluginManagePage.qml
@@ -8,7 +8,7 @@ import waywallen.ui as W
 
 MD.Page {
     id: root
-    title: 'Plugins'
+    title: qsTr('Plugins')
     scrolling: !m_flick.atYBeginning
     readonly property int inactivePluginCount: (pluginListQuery.inactiveSystem ? pluginListQuery.inactiveSystem.length : 0) + (pluginListQuery.inactiveUser ? pluginListQuery.inactiveUser.length : 0)
     readonly property int pluginUpdateStateUnknown: 1
@@ -292,7 +292,7 @@ MD.Page {
         id: zipDialog
         title: qsTr("Choose plugin package")
         fileMode: MD.FileDialog.OpenFile
-        nameFilters: ["Plugin package (*.zip)", "All files (*)"]
+        nameFilters: [qsTr("Plugin package (*.zip)"), qsTr("All files (*)")]
         onAccepted: {
             inspectQuery.zipPath = selectedFile.toString().replace(/^file:\/\//, "");
             inspectQuery.reload();
@@ -413,7 +413,7 @@ MD.Page {
             MD.Text {
                 Layout.fillWidth: true
                 visible: !pluginListQuery.plugins || pluginListQuery.plugins.length === 0
-                text: "No plugins installed"
+                text: qsTr("No plugins installed")
                 typescale: MD.Token.typescale.body_medium
                 color: MD.Token.color.on_surface_variant
                 wrapMode: Text.WordWrap

--- a/ui/qml/page/PluginSettingsPage.qml
+++ b/ui/qml/page/PluginSettingsPage.qml
@@ -11,7 +11,7 @@ import waywallen.ui as W
 // open-time snapshot; edits stay pending until Apply.
 MD.Page {
     id: root
-    title: "Configure " + (displayName.length > 0 ? displayName : pluginName)
+    title: qsTr("Configure %1").arg(displayName.length > 0 ? displayName : pluginName)
     scrolling: !settingsList.atYBeginning
 
     property string pluginName: ""
@@ -140,7 +140,7 @@ MD.Page {
         const buckets = {};
         for (let i = 0; i < schemaList.length; ++i) {
             const s = schemaList[i];
-            const g = (s.group && s.group.length > 0) ? s.group : "General";
+            const g = (s.group && s.group.length > 0) ? s.group : qsTr("General");
             if (!buckets[g])
                 buckets[g] = [];
             buckets[g].push(s);
@@ -179,14 +179,14 @@ MD.Page {
         bottomPadding: 16
 
         MD.Button {
-            text: "Reset"
+            text: qsTr("Reset")
             mdState.type: MD.Enum.BtText
             enabled: root.isDirty
             T.DialogButtonBox.buttonRole: T.DialogButtonBox.ResetRole
             onClicked: root.reset()
         }
         MD.Button {
-            text: "Apply"
+            text: qsTr("Apply")
             mdState.type: MD.Enum.BtText
             enabled: root.isDirty
             T.DialogButtonBox.buttonRole: T.DialogButtonBox.ApplyRole

--- a/ui/qml/page/RemoteInfoPage.qml
+++ b/ui/qml/page/RemoteInfoPage.qml
@@ -5,7 +5,7 @@ import Qcm.Material as MD
 
 MD.Page {
     id: root
-    title: "Remote info"
+    title: qsTr("Remote info")
     scrolling: !infoFlick.atYBeginning
 
     property var itemStore: null
@@ -120,25 +120,25 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.sourceName)
-                label: "Source"
+                label: qsTr("Source")
             }
             InfoValue {
                 visible: root.hasText(root.sourceName)
                 text: root.sourceName
             }
 
-            InfoLabel { label: "Source ID" }
+            InfoLabel { label: qsTr("Source ID") }
             InfoValue { text: root.value(root.item?.sourceId) }
 
-            InfoLabel { label: "Item ID" }
+            InfoLabel { label: qsTr("Item ID") }
             InfoValue { text: root.value(root.item?.itemId) }
 
-            InfoLabel { label: "Title" }
+            InfoLabel { label: qsTr("Title") }
             InfoValue { text: root.value(root.item?.title) }
 
             InfoLabel {
                 visible: root.hasText(root.item?.wpType)
-                label: "Type"
+                label: qsTr("Type")
             }
             InfoValue {
                 visible: root.hasText(root.item?.wpType)
@@ -147,7 +147,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.authorName.length > 0
-                label: "Author"
+                label: qsTr("Author")
             }
             InfoValue {
                 visible: root.authorName.length > 0
@@ -156,7 +156,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.item?.previewUrl)
-                label: "Preview"
+                label: qsTr("Preview")
             }
             InfoValue {
                 visible: root.hasText(root.item?.previewUrl)
@@ -165,7 +165,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.formattedSize)
-                label: "Size"
+                label: qsTr("Size")
             }
             InfoValue {
                 visible: root.hasText(root.formattedSize)
@@ -174,7 +174,7 @@ MD.Page {
 
             InfoLabel {
                 visible: Number(root.details?.width ?? 0) > 0
-                label: "Width"
+                label: qsTr("Width")
             }
             InfoValue {
                 visible: Number(root.details?.width ?? 0) > 0
@@ -183,7 +183,7 @@ MD.Page {
 
             InfoLabel {
                 visible: Number(root.details?.height ?? 0) > 0
-                label: "Height"
+                label: qsTr("Height")
             }
             InfoValue {
                 visible: Number(root.details?.height ?? 0) > 0
@@ -192,7 +192,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.remoteCapability === 1
-                label: "Downloaded"
+                label: qsTr("Downloaded")
             }
             InfoValue {
                 visible: root.remoteCapability === 1
@@ -201,7 +201,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.remoteCapability === 2
-                label: "Subscription"
+                label: qsTr("Subscription")
             }
             InfoValue {
                 visible: root.remoteCapability === 2
@@ -210,7 +210,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.remoteHint)
-                label: "Acquisition"
+                label: qsTr("Acquisition")
             }
             InfoValue {
                 visible: root.hasText(root.remoteHint)
@@ -219,7 +219,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.tagsText)
-                label: "Tags"
+                label: qsTr("Tags")
             }
             InfoValue {
                 visible: root.hasText(root.tagsText)
@@ -228,7 +228,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.details?.description)
-                label: "Description"
+                label: qsTr("Description")
             }
             InfoValue {
                 visible: root.hasText(root.details?.description)

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -12,7 +12,7 @@ MD.Page {
     padding: 0
     showHeader: true
     showBackground: false
-    title: 'Settings'
+    title: qsTr('Settings')
     scrolling: !m_flick.atYBeginning
 
     actions: [

--- a/ui/qml/page/SourceManagePage.qml
+++ b/ui/qml/page/SourceManagePage.qml
@@ -50,7 +50,7 @@ MD.Page {
                 text: fullPath
                 wrapMode: Text.Wrap
                 maximumLineCount: 3
-                supportText: "Plugin: " + modelData.pluginName
+                supportText: qsTr("Plugin: %1").arg(modelData.pluginName)
 
                 leader: MD.Icon {
                     name: MD.Token.icon.folder

--- a/ui/qml/page/StatusPage.qml
+++ b/ui/qml/page/StatusPage.qml
@@ -11,7 +11,7 @@ MD.Page {
     padding: 0
     showHeader: MD.MProp.size.isCompact
     showBackground: false
-    title: 'Status'
+    title: qsTr('Status')
 
     actions: [
         MD.Action {
@@ -143,12 +143,12 @@ MD.Page {
         id: killDialog
         property string rendererId: ""
         property string label: ""
-        title: "Kill renderer?"
+        title: qsTr("Kill renderer?")
         parent: T.Overlay.overlay
         standardButtons: T.Dialog.Cancel | T.Dialog.Ok
 
         contentItem: MD.Text {
-            text: "Stop the renderer process\n\"" + killDialog.label + "\"?\nUnsaved frame state may be lost."
+            text: qsTr("Stop the renderer process\n\"%1\"?\nUnsaved frame state may be lost.").arg(killDialog.label)
             typescale: MD.Token.typescale.body_medium
             color: MD.Token.color.on_surface_variant
             wrapMode: Text.WordWrap
@@ -177,13 +177,13 @@ MD.Page {
                     spacing: 8
 
                     SectionTitle {
-                        text: "Daemon"
+                        text: qsTr("Daemon")
                     }
 
                     RowLayout {
                         spacing: 8
                         MD.Text {
-                            text: "Service:"
+                            text: qsTr("Service:")
                             typescale: MD.Token.typescale.label_medium
                             color: MD.Token.color.on_surface_variant
                         }
@@ -212,7 +212,7 @@ MD.Page {
                     RowLayout {
                         spacing: 8
                         MD.Text {
-                            text: "State:"
+                            text: qsTr("State:")
                             typescale: MD.Token.typescale.label_medium
                             color: MD.Token.color.on_surface_variant
                         }
@@ -239,13 +239,13 @@ MD.Page {
                     spacing: 8
 
                     SectionTitle {
-                        text: "Active Renderers"
+                        text: qsTr("Active Renderers")
                     }
 
                     SectionHint {
                         readonly property var liveRenderers: W.App.rendererManager.renderers
                         visible: !liveRenderers || liveRenderers.length === 0
-                        text: "No active renderers"
+                        text: qsTr("No active renderers")
                     }
 
                     ListView {
@@ -310,18 +310,18 @@ MD.Page {
                     spacing: 8
 
                     SectionTitle {
-                        text: "Components"
+                        text: qsTr("Components")
                     }
 
                     SectionHint {
                         typescale: MD.Token.typescale.label_medium
                         visible: pluginQuery.supportedTypes && pluginQuery.supportedTypes.length > 0
-                        text: "Supported types: " + (pluginQuery.supportedTypes ? pluginQuery.supportedTypes.join(", ") : "")
+                        text: qsTr("Supported types: %1").arg(pluginQuery.supportedTypes ? pluginQuery.supportedTypes.join(", ") : "")
                     }
 
                     SectionHint {
                         visible: !pluginQuery.renderers || pluginQuery.renderers.length === 0
-                        text: "No components"
+                        text: qsTr("No components")
                     }
 
                     ListView {

--- a/ui/qml/page/WallpaperCard.qml
+++ b/ui/qml/page/WallpaperCard.qml
@@ -76,7 +76,7 @@ Item {
                 anchors.right : parent.right
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 6
-                text: root.wallpaper?.name || "Untitled"
+                text: root.wallpaper?.name || qsTr("Untitled")
                 typescale: MD.Token.typescale.title_small
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter

--- a/ui/qml/page/WallpaperDetailPanel.qml
+++ b/ui/qml/page/WallpaperDetailPanel.qml
@@ -24,7 +24,7 @@ Item {
     property var applyTargetIds: []
     property int rendererIndex: 0
     readonly property var kFillModeValues: [1, 2, 3, 7]
-    readonly property var kFillModeLabels: ["Stretch", "Fit", "Crop", "Center"]
+    readonly property var kFillModeLabels: [qsTr("Stretch"), qsTr("Fit"), qsTr("Crop"), qsTr("Center")]
     readonly property var kRotationValues: [1, 2, 3, 4]
     readonly property var kRotationLabels: ["0°", "90°", "180°", "270°"]
     readonly property bool wallpaperLayoutOverrideSet: root.wp?.wallpaperLayoutOverrideSet ?? false
@@ -151,16 +151,16 @@ Item {
         target: portalApplyQuery
         function onStatusChanged() {
             if (portalApplyQuery.status === 3)
-                W.Action.toast("Portal apply failed");
+                W.Action.toast(qsTr("Portal apply failed"));
             else if (portalApplyQuery.status === 2)
-                W.Action.toast("Wallpaper sent to desktop portal");
+                W.Action.toast(qsTr("Wallpaper sent to desktop portal"));
         }
     }
 
     Connections {
         target: removeQuery
         function onRemoved() {
-            W.Action.toast("Wallpaper removed");
+            W.Action.toast(qsTr("Wallpaper removed"));
             root.back();
         }
         function onStatusChanged() {
@@ -205,7 +205,7 @@ Item {
             if (layoutSetQuery.status === 2)
                 wallpaperGetQuery.reload();
             else if (layoutSetQuery.status === 3)
-                W.Action.toast("Layout update failed");
+                W.Action.toast(qsTr("Layout update failed"));
         }
     }
 
@@ -277,7 +277,7 @@ Item {
 
     MD.Action {
         id: applyAction
-        text: "Apply"
+        text: qsTr("Apply")
         busy: applyQuery.querying
         enabled: (W.App.displayManager.displays || []).length > 0
         onTriggered: {
@@ -297,7 +297,7 @@ Item {
 
     MD.Action {
         id: applyViaPortalAction
-        text: "Apply via desktop portal"
+        text: qsTr("Apply via desktop portal")
         busy: portalApplyQuery.querying
         onTriggered: {
             if (busy) return;
@@ -309,14 +309,14 @@ Item {
 
     MD.Action {
         id: closeAction
-        text: "Close"
+        text: qsTr("Close")
         icon.name: MD.Token.icon.close
         onTriggered: root.back()
     }
 
     MD.Action {
         id: infoAction
-        text: "Info"
+        text: qsTr("Info")
         icon.name: MD.Token.icon.info
         enabled: (root.wp?.id_proto ?? "") !== ""
         onTriggered: root.openInfo()
@@ -324,7 +324,7 @@ Item {
 
     MD.Action {
         id: openContainerFolderAction
-        text: "Open containing folder"
+        text: qsTr("Open containing folder")
         icon.name: MD.Token.icon.folder_open
         enabled: root.containerFolderUrl(root.wp?.resource).length > 0
         onTriggered: root.openContainerFolder()
@@ -332,7 +332,7 @@ Item {
 
     MD.Action {
         id: removeAction
-        text: "Remove"
+        text: qsTr("Remove")
         icon.name: MD.Token.icon.delete
         busy: removeQuery.querying
         enabled: (root.wp?.supportsItemRemove ?? false) && (root.wp?.id_proto ?? "") !== ""
@@ -405,7 +405,7 @@ Item {
 
                 MD.Text {
                     Layout.fillWidth: true
-                    text: root.wp?.name || "Untitled"
+                    text: root.wp?.name || qsTr("Untitled")
                     typescale: MD.Token.typescale.title_large
                     color: MD.Token.color.on_surface
                     wrapMode: Text.Wrap
@@ -461,7 +461,7 @@ Item {
 
                     MD.Text {
                         visible: m_meta.hasPath
-                        text: "Path"
+                        text: qsTr("Path")
                         typescale: MD.Token.typescale.label_medium
                         color: MD.Token.color.on_surface_variant
                     }
@@ -478,7 +478,7 @@ Item {
 
                     MD.Text {
                         visible: m_meta.hasResolution
-                        text: "Resolution"
+                        text: qsTr("Resolution")
                         typescale: MD.Token.typescale.label_medium
                         color: MD.Token.color.on_surface_variant
                     }
@@ -491,7 +491,7 @@ Item {
 
                     MD.Text {
                         visible: m_meta.hasSize
-                        text: "Size"
+                        text: qsTr("Size")
                         typescale: MD.Token.typescale.label_medium
                         color: MD.Token.color.on_surface_variant
                     }
@@ -504,7 +504,7 @@ Item {
 
                     MD.Text {
                         visible: m_meta.hasFormat
-                        text: "Format"
+                        text: qsTr("Format")
                         typescale: MD.Token.typescale.label_medium
                         color: MD.Token.color.on_surface_variant
                     }
@@ -545,7 +545,7 @@ Item {
                         spacing: 4
                         MD.Text {
                             Layout.fillWidth: true
-                            text: "Description"
+                            text: qsTr("Description")
                             typescale: MD.Token.typescale.label_large
                             color: MD.Token.color.on_surface_variant
                         }
@@ -583,7 +583,7 @@ Item {
 
                         MD.Text {
                             Layout.fillWidth: true
-                            text: "Layout override"
+                            text: qsTr("Layout override")
                             typescale: MD.Token.typescale.label_large
                             color: MD.Token.color.on_surface_variant
                         }
@@ -594,7 +594,7 @@ Item {
                             enabled: root.wallpaperLayoutOverrideSet
                             onClicked: root.resetWallpaperLayout()
                             MD.ToolTip.visible: hovered
-                            MD.ToolTip.text: "Reset to display layout"
+                            MD.ToolTip.text: qsTr("Reset to display layout")
                         }
                     }
 
@@ -615,7 +615,7 @@ Item {
                             spacing: 4
 
                             MD.Text {
-                                text: "Fill mode"
+                                text: qsTr("Fill mode")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -641,7 +641,7 @@ Item {
                             opacity: enabled ? 1.0 : 0.4
 
                             MD.Text {
-                                text: "Horizontal"
+                                text: qsTr("Horizontal")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -671,7 +671,7 @@ Item {
                             opacity: enabled ? 1.0 : 0.4
 
                             MD.Text {
-                                text: "Vertical"
+                                text: qsTr("Vertical")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -699,7 +699,7 @@ Item {
                             spacing: 4
 
                             MD.Text {
-                                text: "Rotation"
+                                text: qsTr("Rotation")
                                 typescale: MD.Token.typescale.label_medium
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -783,7 +783,7 @@ Item {
                                 propertyModel.resetUserProperties();
                         }
                         MD.ToolTip.visible: hovered
-                        MD.ToolTip.text: "Reset to defaults"
+                        MD.ToolTip.text: qsTr("Reset to defaults")
                     }
                 }
             }
@@ -918,13 +918,13 @@ Item {
                         enabled: m_text_input.text !== m_prop_delegate.currentValue
                         onClicked: m_text_input.submit()
                         MD.ToolTip.visible: hovered
-                        MD.ToolTip.text: "Apply"
+                        MD.ToolTip.text: qsTr("Apply")
                     }
                 }
 
                 MD.Text {
                     visible: !m_prop_delegate.supported
-                    text: "(" + m_prop_delegate.type + " — not yet supported)"
+                    text: qsTr("(%1 — not yet supported)").arg(m_prop_delegate.type)
                     typescale: MD.Token.typescale.body_small
                     color: MD.Token.color.on_surface_variant
                 }
@@ -946,7 +946,7 @@ Item {
                 visible: (W.App.displayManager.displays || []).length > 0
 
                 MD.Text {
-                    text: "Apply to"
+                    text: qsTr("Apply to")
                     typescale: MD.Token.typescale.label_medium
                     color: MD.Token.color.on_surface_variant
                 }
@@ -956,7 +956,7 @@ Item {
                     spacing: 6
 
                     MD.FilterChip {
-                        text: "All"
+                        text: qsTr("All")
                         checked: root.isTargetAll()
                         onClicked: root.applyTargetIds = []
                     }
@@ -966,7 +966,7 @@ Item {
                         MD.FilterChip {
                             required property var modelData
                             width: Math.min(implicitWidth, 220)
-                            text: (modelData?.displayLabel ?? "") || (modelData?.name ?? "").replace(/^waywallen-[a-z]+-[a-z]+-/, "") || ("Display " + modelData?.id)
+                            text: (modelData?.displayLabel ?? "") || (modelData?.name ?? "").replace(/^waywallen-[a-z]+-[a-z]+-/, "") || qsTr("Display %1").arg(modelData?.id)
                             checked: root.applyTargetIds.indexOf(modelData?.id) >= 0
                             onClicked: root.toggleTarget(modelData?.id)
                         }
@@ -980,7 +980,7 @@ Item {
                 visible: root.rendererCandidates.length >= 2
 
                 MD.Text {
-                    text: "Renderer"
+                    text: qsTr("Renderer")
                     typescale: MD.Token.typescale.label_medium
                     color: MD.Token.color.on_surface_variant
                 }
@@ -1007,7 +1007,7 @@ Item {
                 action: root.activeApplyAction
                 mdState.type: MD.Enum.BtFilled
                 MD.ToolTip.visible: applyBtn.hovered && !applyBtn.enabled
-                MD.ToolTip.text: "No display connected"
+                MD.ToolTip.text: qsTr("No display connected")
             }
         }
     }

--- a/ui/qml/page/WallpaperInfoPage.qml
+++ b/ui/qml/page/WallpaperInfoPage.qml
@@ -5,7 +5,7 @@ import Qcm.Material as MD
 
 MD.Page {
     id: root
-    title: "Wallpaper info"
+    title: qsTr("Wallpaper info")
     scrolling: !infoFlick.atYBeginning
 
     property var wallpaper: null
@@ -109,30 +109,30 @@ MD.Page {
             columnSpacing: 12
             rowSpacing: 10
 
-            InfoLabel { label: "ID" }
+            InfoLabel { label: qsTr("ID") }
             InfoValue { text: root.value(root.wallpaper?.id_proto) }
 
             InfoLabel {
                 visible: root.hasText(root.wallpaper?.externalId)
-                label: "External ID"
+                label: qsTr("External ID")
             }
             InfoValue {
                 visible: root.hasText(root.wallpaper?.externalId)
                 text: root.value(root.wallpaper?.externalId)
             }
 
-            InfoLabel { label: "Name" }
+            InfoLabel { label: qsTr("Name") }
             InfoValue { text: root.value(root.wallpaper?.name) }
 
-            InfoLabel { label: "Type" }
+            InfoLabel { label: qsTr("Type") }
             InfoValue { text: root.value(root.wallpaper?.wpType) }
 
-            InfoLabel { label: "Resource" }
+            InfoLabel { label: qsTr("Resource") }
             InfoValue { text: root.value(root.wallpaper?.resource) }
 
             InfoLabel {
                 visible: root.hasText(root.wallpaper?.preview)
-                label: "Preview"
+                label: qsTr("Preview")
             }
             InfoValue {
                 visible: root.hasText(root.wallpaper?.preview)
@@ -141,7 +141,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.sizeBytes > 0
-                label: "Size"
+                label: qsTr("Size")
             }
             InfoValue {
                 visible: root.sizeBytes > 0
@@ -150,7 +150,7 @@ MD.Page {
 
             InfoLabel {
                 visible: Number(root.wallpaper?.width ?? 0) > 0
-                label: "Width"
+                label: qsTr("Width")
             }
             InfoValue {
                 visible: Number(root.wallpaper?.width ?? 0) > 0
@@ -159,7 +159,7 @@ MD.Page {
 
             InfoLabel {
                 visible: Number(root.wallpaper?.height ?? 0) > 0
-                label: "Height"
+                label: qsTr("Height")
             }
             InfoValue {
                 visible: Number(root.wallpaper?.height ?? 0) > 0
@@ -168,7 +168,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.formatText)
-                label: "Format"
+                label: qsTr("Format")
             }
             InfoValue {
                 visible: root.hasText(root.formatText)
@@ -177,7 +177,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.wallpaper?.contentRating)
-                label: "Rating"
+                label: qsTr("Rating")
             }
             InfoValue {
                 visible: root.hasText(root.wallpaper?.contentRating)
@@ -186,7 +186,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.tagsText)
-                label: "Tags"
+                label: qsTr("Tags")
             }
             InfoValue {
                 visible: root.hasText(root.tagsText)
@@ -195,7 +195,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.wallpaper?.description)
-                label: "Description"
+                label: qsTr("Description")
             }
             InfoValue {
                 visible: root.hasText(root.wallpaper?.description)
@@ -204,7 +204,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.metadataText)
-                label: "Metadata"
+                label: qsTr("Metadata")
             }
             InfoValue {
                 visible: root.hasText(root.metadataText)
@@ -213,7 +213,7 @@ MD.Page {
 
             InfoLabel {
                 visible: root.hasText(root.overridesText)
-                label: "Overrides"
+                label: qsTr("Overrides")
             }
             InfoValue {
                 visible: root.hasText(root.overridesText)

--- a/ui/qml/page/WallpaperPage.qml
+++ b/ui/qml/page/WallpaperPage.qml
@@ -191,9 +191,9 @@ MD.Page {
         target: W.Notify
         function onWallpaperSyncFinished(count, error) {
             if (error && error.length > 0) {
-                W.Action.toast("Sync failed: " + error);
+                W.Action.toast(qsTr("Sync failed: %1").arg(error));
             } else {
-                W.Action.toast("Scanned " + count + " wallpapers");
+                W.Action.toast(qsTr("Scanned %n wallpaper(s)", "", count));
             }
             wallpaperQuery.reload();
         }
@@ -222,7 +222,7 @@ MD.Page {
 
     MD.Action {
         id: createPlaylistFromSelectionAction
-        text: "New playlist"
+        text: qsTr("New playlist")
         icon.name: MD.Token.icon.playlist_add
         busy: playlistMutation.querying
         checked: wallpaperSelectSheetRelay.activeAction === createPlaylistFromSelectionAction
@@ -232,7 +232,7 @@ MD.Page {
 
     MD.Action {
         id: addToPlaylistAction
-        text: "Add to playlist"
+        text: qsTr("Add to playlist")
         icon.name: MD.Token.icon.playlist_add
         checked: wallpaperSelectSheetRelay.activeAction === addToPlaylistAction
         enabled: root.selectedWallpaperCount > 0 && (playlistListQuery.playlists || []).length > 0 && !playlistMutation.querying
@@ -241,7 +241,7 @@ MD.Page {
 
     MD.Action {
         id: applyPlaylistSelectionAction
-        text: "Apply"
+        text: qsTr("Apply")
         icon.name: MD.Token.icon.check
         busy: playlistMutation.querying
         enabled: playlistWallpaperSelect.playlistEditTargetId > 0 && !playlistMutation.querying
@@ -259,7 +259,7 @@ MD.Page {
 
     MD.Action {
         id: playlistListAction
-        text: "Playlists"
+        text: qsTr("Playlists")
         icon.name: MD.Token.icon.playlist_play
         checked: W.App.displayManager.hasActivePlaylistDisplays
         onTriggered: root.togglePlaylistListSheet()
@@ -267,7 +267,7 @@ MD.Page {
 
     MD.Action {
         id: tweakAction
-        text: "Tweak"
+        text: qsTr("Tweak")
         icon.name: MD.Token.icon.tune
         checked: root.isSheetActive(root.wallpaperTweakSheet)
         onTriggered: root.toggleWallpaperTweakSheet()
@@ -276,7 +276,7 @@ MD.Page {
     MD.Action {
         id: filterAction
         icon.name: MD.Token.icon.filter_list
-        text: "Filters"
+        text: qsTr("Filters")
         checked: wallpaperQuery.hasActiveFilters
         onTriggered: MD.Util.showPopup(filterDialogComponent, {}, root.Window.window)
     }
@@ -293,7 +293,7 @@ MD.Page {
     MD.Action {
         id: refreshAction
         icon.name: MD.Token.icon.refresh
-        text: "Refresh"
+        text: qsTr("Refresh")
         enabled: !W.Notify.scanInProgress
         onTriggered: scanQuery.reload()
     }
@@ -1094,7 +1094,7 @@ MD.Page {
                             MD.Text {
                                 Layout.alignment: Qt.AlignHCenter
                                 visible: !wallpaperQuery.querying
-                                text: "No wallpapers found"
+                                text: qsTr("No wallpapers found")
                                 typescale: MD.Token.typescale.body_large
                                 color: MD.Token.color.on_surface_variant
                             }
@@ -1120,7 +1120,7 @@ MD.Page {
                                 // (in that case the user wants Refresh, not a
                                 // second round of auto-detection).
                                 visible: parent.showLibraryHint
-                                text: "Auto detect libraries"
+                                text: qsTr("Auto detect libraries")
                                 busy: autoDetectQuery.querying
                                 mdState.type: MD.Enum.BtFilledTonal
                                 onClicked: {

--- a/ui/qml/page/wallpaper/AddToPlaylistSheetContent.qml
+++ b/ui/qml/page/wallpaper/AddToPlaylistSheetContent.qml
@@ -67,7 +67,7 @@ ColumnLayout {
                 width: ListView.view.contentWidth
                 radius: 12
                 text: modelData.name || qsTr("Untitled")
-                supportText: qsTr("%1 wallpapers").arg((modelData.entryIds || []).length)
+                supportText: qsTr("%n wallpaper(s)", "", (modelData.entryIds || []).length)
 
                 trailing: MD.BusyIconButton {
                     enabled: control.sheetState.selectedWallpaperCount > 0

--- a/ui/qml/page/wallpaper/PlaylistListSheet.qml
+++ b/ui/qml/page/wallpaper/PlaylistListSheet.qml
@@ -118,7 +118,7 @@ MD.BottomSheet {
                 width: ListView.view.contentWidth
                 radius: 12
                 text: modelData.name || qsTr("Untitled")
-                supportText: qsTr("%1 wallpapers").arg((modelData.entryIds || []).length)
+                supportText: qsTr("%n wallpaper(s)", "", (modelData.entryIds || []).length)
                 heightMode: playingDisplayLabels.length > 0
                     ? MD.Enum.ListItemThreeLine
                     : MD.Enum.ListItemTwoLine


### PR DESCRIPTION
Most of the QML already goes through `qsTr()`, but a handful of pages still held plain literals, so a translated build would come out half English. This wraps the leftovers and turns the string concatenations that build a sentence into `qsTr()` with `%1` placeholders, so a translator can reorder the parts.

No behaviour change on its own: without a catalog loaded `qsTr()` returns the source string, and this branch adds no catalog and touches nothing outside `ui/qml`.

### The one place I did not stay literal

Two counted strings are folded into `%n` plural forms rather than kept as-is:

* `qsTr("%1 wallpapers").arg(n)` -> `qsTr("%n wallpaper(s)", "", n)` (playlist sheets)
* `"Scanned " + count + " wallpapers"` -> `qsTr("Scanned %n wallpaper(s)", "", count)`
* `n === 1 ? "Library added" : (n + " libraries added")` -> `qsTr("%n library(s) added", "", n)`

The English text is unchanged for `n != 1` and the ternary already encoded the singular case, so nothing regresses. The reason for the change is that plenty of languages have more than two plural categories - Russian picks a different form for 1, for 2-4 and for 5+, and Polish, Czech and Arabic split differently again. With `%1` a translator has no way to express that; `%n` is the mechanism Qt provides for it. Happy to revert these three if you would rather keep the sources byte-identical.

### Checked

Built the UI from this branch and ran it; strings render exactly as before.
