### PR TITLE
assets: translate the desktop entry and AppStream data to Russian

### DIFF
--- a/ui/assets/waywallen-ui.desktop.in
+++ b/ui/assets/waywallen-ui.desktop.in
@@ -2,10 +2,13 @@
 Type=Application
 Name=Waywallen
 GenericName=Wallpaper Manager for Linux
+GenericName[ru]=Менеджер обоев для Linux
 Comment=@APP_SUMMARY@
+Comment[ru]=Менеджер обоев для Linux
 Exec=waywallen
 Icon=@APP_ID@
 Terminal=false
 Categories=Graphics;Qt;
 Keywords=wallpaper;pipewire;vulkan;
+Keywords[ru]=обои;живые обои;рабочий стол;wallpaper;pipewire;vulkan;
 StartupNotify=true

--- a/ui/assets/waywallen-ui.metainfo.xml.in
+++ b/ui/assets/waywallen-ui.metainfo.xml.in
@@ -6,16 +6,21 @@
 
   <name>@APP_NAME@</name>
   <summary>@APP_SUMMARY@</summary>
+  <summary xml:lang="ru">Менеджер обоев для Linux</summary>
 
   <description>
     <p>
       Waywallen is a dynamic wallpaper solution for Linux desktops with local media libraries, plugin-based discovery, and per-display controls.
+    </p>
+    <p xml:lang="ru">
+      Waywallen — живые обои для рабочих столов Linux: локальные библиотеки, поиск дополнений через плагины и отдельные настройки для каждого монитора.
     </p>
   </description>
 
   <screenshots>
       <screenshot type="default">
         <caption>main window</caption>
+        <caption xml:lang="ru">главное окно</caption>
         <image type="source">https://github.com/waywallen/waywallen/raw/refs/heads/main/ui/assets/main_page.webp</image>
       </screenshot>
   </screenshots>


### PR DESCRIPTION
The launcher entry and the AppStream metadata are English-only, so the application menu and the software centre show an English description even in a fully localized session. Nothing in the build needs changing for this - `.desktop` files take `Key[lang]` and AppStream takes `xml:lang` natively - so this is data only and independent of #174 and #175.

Adds `GenericName[ru]`, `Comment[ru]` and `Keywords[ru]` to the desktop entry, and `<summary xml:lang="ru">`, a translated `<p>` and a translated screenshot `<caption>` to the metainfo. Another language only needs the same keys added next to them.

`Comment[ru]` carries the same text as `GenericName[ru]` because `Comment=@APP_SUMMARY@` and `GenericName` are already identical upstream, and Plasma prefers `Comment` when the entry has one, so leaving it out would have shown the English string. `desktop-file-validate` notes the duplication, as it already does for the English pair.

### Checked

`desktop-file-validate` and `appstreamcli validate --no-net` both pass on the generated files. Installed the generated `.desktop` into a user prefix on KDE Plasma 6, ran `update-desktop-database` and `kbuildsycoca6 --noincremental`, and the launcher shows "Waywallen - Менеджер обоев для Linux".
