### PR TITLE
feat(ui): support localized filter value labels

### DIFF
--- a/proto/control.proto
+++ b/proto/control.proto
@@ -738,6 +738,8 @@ message RemoteFilterDef {
   repeated string values = 4;
   string description = 5;
   string confirmation = 6;
+  // Optional display labels parallel to values. Clients submit values, never labels.
+  repeated string value_labels = 7;
 }
 
 message RemoteSourceInfo {

--- a/src/plugin/source_manager.rs
+++ b/src/plugin/source_manager.rs
@@ -172,6 +172,7 @@ pub struct DiscoverFilter {
     pub title: String,
     pub ty: DiscoverFilterType,
     pub values: Vec<String>,
+    pub value_labels: Vec<String>,
     pub description: String,
     pub confirmation: String,
 }
@@ -833,6 +834,7 @@ impl LuaPluginRuntime {
             title: "Tags".to_string(),
             ty: DiscoverFilterType::MultiSelect,
             values: tags,
+            value_labels: Vec::new(),
             description: String::new(),
             confirmation: String::new(),
         }]
@@ -881,6 +883,7 @@ impl LuaPluginRuntime {
                 }
             };
             let values = Self::require_string_sequence(&filter, "values", &context)?;
+            let value_labels = Self::optional_string_sequence(&filter, "value_labels", &context)?;
             if values.is_empty() {
                 return Err(Error::Internal(anyhow!(
                     "{context}.values must not be empty"
@@ -889,6 +892,16 @@ impl LuaPluginRuntime {
             if ty == DiscoverFilterType::Toggle && values.len() != 1 {
                 return Err(Error::Internal(anyhow!(
                     "{context}.values must contain exactly one value for a toggle"
+                )));
+            }
+            if !value_labels.is_empty() && value_labels.len() != values.len() {
+                return Err(Error::Internal(anyhow!(
+                    "{context}.value_labels must be empty or contain one label per value"
+                )));
+            }
+            if value_labels.iter().any(String::is_empty) {
+                return Err(Error::Internal(anyhow!(
+                    "{context}.value_labels must not contain an empty label"
                 )));
             }
             for value in &values {
@@ -916,6 +929,7 @@ impl LuaPluginRuntime {
                 title,
                 ty,
                 values,
+                value_labels,
                 description,
                 confirmation,
             });
@@ -4995,7 +5009,13 @@ function M.info()
             discover = {
                 search = true,
                 filters = {
-                    { id = "kind", title = "Kind", type = "select", values = { "A", "B" } },
+                    {
+                        id = "kind",
+                        title = "Kind",
+                        type = "select",
+                        values = { "A", "B" },
+                        value_labels = { "Alpha", "Beta" },
+                    },
                     { id = "tags", title = "Tags", type = "multi_select", values = { "X", "Y" } },
                 },
             },
@@ -5012,6 +5032,10 @@ return M
         let mgr = SourceManager::new().unwrap();
         mgr.load_plugin(&path, "test.plugin", "1.0", ENTRY_VERSION_V3)
             .unwrap();
+        assert_eq!(
+            mgr.discover_sources().unwrap()[0].filters[0].value_labels,
+            vec!["Alpha", "Beta"]
+        );
         assert!(block_value(async {
             mgr.call_discover("filters", "", "", 1, &["A".to_string(), "X".to_string()])
                 .await

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -2243,6 +2243,7 @@ async fn dispatch_inner(
                                         }
                                     },
                                     values: filter.values,
+                                    value_labels: filter.value_labels,
                                     description: filter.description,
                                     confirmation: filter.confirmation,
                                 })

--- a/ui/qml/component/filter/TagPickerDialog.qml
+++ b/ui/qml/component/filter/TagPickerDialog.qml
@@ -10,6 +10,7 @@ MD.Dialog {
     id: control
 
     property var allTags: []
+    property var tagLabels: []
     property var selected: []
     property string dialogTitle: qsTr("Select tags")
     signal commit(var tags)
@@ -29,6 +30,11 @@ MD.Dialog {
         else
             next.push(tag);
         control.pending = next;
+    }
+    function labelFor(tag) {
+        const index = (control.allTags || []).indexOf(tag);
+        return index >= 0 && index < (control.tagLabels || []).length
+            ? String(control.tagLabels[index]) : String(tag);
     }
 
     // True when the pending selection actually differs from what was
@@ -93,7 +99,7 @@ MD.Dialog {
                     delegate: MD.FilterChip {
                         required property var modelData
                         checkable: false
-                        text: modelData
+                        text: control.labelFor(modelData)
                         checked: (control.pending || []).indexOf(modelData) >= 0
                         onClicked: control.togglePending(modelData)
                     }

--- a/ui/qml/dialog/RemoteFilterDialog.qml
+++ b/ui/qml/dialog/RemoteFilterDialog.qml
@@ -36,6 +36,15 @@ MD.Dialog {
     function filterValues(filter) {
         return sanitize(filter && filter.values ? filter.values : []);
     }
+    function filterLabels(filter) {
+        const values = filterValues(filter);
+        const labels = Array.from(filter && filter.valueLabels ? filter.valueLabels : [], label => String(label));
+        return labels.length === values.length ? labels : values;
+    }
+    function labelFor(filter, value) {
+        const index = filterValues(filter).indexOf(value);
+        return index >= 0 ? filterLabels(filter)[index] : String(value);
+    }
     function selectedMap() {
         let allowed = {};
         for (const filter of filters ?? []) {
@@ -80,7 +89,7 @@ MD.Dialog {
         root.apply(collect(filter, values));
     }
     function selectOptions(filter) {
-        return [qsTr("Any")].concat(filterValues(filter));
+        return [qsTr("Any")].concat(filterLabels(filter));
     }
     function selectIndex(filter) {
         const selected = selectedFor(filter);
@@ -128,6 +137,7 @@ MD.Dialog {
         W.TagPickerDialog {
             dialogTitle: root.activeFilter ? String(root.activeFilter.title ?? "") : qsTr("Select values")
             allTags: root.filterValues(root.activeFilter)
+            tagLabels: root.filterLabels(root.activeFilter)
             selected: root.selectedFor(root.activeFilter)
             onCommit: function (values) {
                 root.setFilterValues(root.activeFilter, values);
@@ -228,7 +238,7 @@ MD.Dialog {
                                 model: root.selectedFor(filterRow.modelData)
                                 delegate: W.Tag {
                                     required property var modelData
-                                    text: modelData
+                                    text: root.labelFor(filterRow.modelData, modelData)
                                 }
                             }
                         }

--- a/ui/src/query/remote_query.cpp
+++ b/ui/src/query/remote_query.cpp
@@ -57,10 +57,13 @@ void RemoteAvailabilityQuery::reload() {
                     QVariantMap fm;
                     QStringList values;
                     for (const auto& value : filter.values()) values.push_back(value);
+                    QStringList valueLabels;
+                    for (const auto& label : filter.valueLabels()) valueLabels.push_back(label);
                     fm[u"id"_s]           = filter.id_proto();
                     fm[u"title"_s]        = filter.title();
                     fm[u"type"_s]         = static_cast<int>(filter.type());
                     fm[u"values"_s]       = values;
+                    fm[u"valueLabels"_s]  = valueLabels;
                     fm[u"description"_s]  = filter.description();
                     fm[u"confirmation"_s] = filter.confirmation();
                     filters.push_back(fm);


### PR DESCRIPTION
Add human-readable labels for remote filter values while preserving the original machine-readable values used by filtering logic.

- Add value_labels to RemoteFilterDef.
- Parse and validate value_labels from Lua plugin metadata.
- Propagate labels through the WebSocket API and C++ query model.
- Display localized labels in filter lists and selected chips.
- Fall back to raw values when labels are absent.

Related: https://github.com/waywallen/open-wallpaper-engine/pull/91