### PR TITLE
playlist: share synced multi-display playback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,11 +60,9 @@ sea-orm-migration = { version = "1.1", default-features = false, features = [
 tempfile = "3"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 
-# Skip `cargo test` harnesses for binaries that hold no bin-specific tests.
 [[bin]]
 name = "waywallen"
 path = "src/main.rs"
-test = false
 
 [[bin]]
 name = "waywallen_display_demo"

--- a/src/control.rs
+++ b/src/control.rs
@@ -44,6 +44,14 @@ pub struct ApplyOptions {
     pub force_shared_renderer: bool,
 }
 
+fn should_duplicate_renderers(
+    setting_enabled: bool,
+    has_targets: bool,
+    force_shared: bool,
+) -> bool {
+    setting_enabled && has_targets && !force_shared
+}
+
 pub struct PluginInstallResult {
     pub plugin_id: String,
     pub needs_restart: bool,
@@ -1087,9 +1095,11 @@ pub async fn apply_wallpaper_with_options(
     if options.require_display && target_ids.is_empty() {
         return Err(Error::NoDisplayRegistered);
     }
-    let duplicate_renderers = app.settings.global().duplicate_renderers_for_same_wallpaper
-        && !target_ids.is_empty()
-        && !options.force_shared_renderer;
+    let duplicate_renderers = should_duplicate_renderers(
+        app.settings.global().duplicate_renderers_for_same_wallpaper,
+        !target_ids.is_empty(),
+        options.force_shared_renderer,
+    );
     let renderer_id = if duplicate_renderers {
         apply_duplicate_renderers(
             app,
@@ -1798,4 +1808,22 @@ async fn refresh_sources_inner(app: &Arc<AppState>) -> Result<usize> {
         return Err(e);
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn force_shared_disables_duplicate_path() {
+        assert!(!should_duplicate_renderers(true, true, true));
+    }
+
+    #[test]
+    fn duplicate_only_when_setting_and_targets() {
+        assert!(should_duplicate_renderers(true, true, false));
+        assert!(!should_duplicate_renderers(false, true, false));
+        assert!(!should_duplicate_renderers(true, false, false));
+        assert!(!should_duplicate_renderers(true, false, true));
+    }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -41,6 +41,7 @@ pub struct ApplyOptions {
     pub renderer_name: Option<String>,
     pub first_frame_timeout: Option<Duration>,
     pub require_display: bool,
+    pub force_shared_renderer: bool,
 }
 
 pub struct PluginInstallResult {
@@ -824,6 +825,30 @@ pub async fn apply_wallpaper_to_displays_with_first_frame_timeout(
     .await
 }
 
+pub async fn apply_wallpaper_shared_to_displays(
+    app: &Arc<AppState>,
+    id: &str,
+    target: &[DisplayId],
+    first_frame_timeout: Option<Duration>,
+) -> Result<ApplyResult> {
+    if target.is_empty() {
+        return Err(Error::Internal(anyhow!(
+            "apply_wallpaper_shared_to_displays: empty target"
+        )));
+    }
+    apply_wallpaper_with_options(
+        app,
+        id,
+        ApplyOptions {
+            display_ids: Some(target.to_vec()),
+            first_frame_timeout,
+            force_shared_renderer: true,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
 pub struct PortalApplyResult {
     pub wallpaper_id: String,
     pub uri: String,
@@ -1062,8 +1087,9 @@ pub async fn apply_wallpaper_with_options(
     if options.require_display && target_ids.is_empty() {
         return Err(Error::NoDisplayRegistered);
     }
-    let duplicate_renderers =
-        app.settings.global().duplicate_renderers_for_same_wallpaper && !target_ids.is_empty();
+    let duplicate_renderers = app.settings.global().duplicate_renderers_for_same_wallpaper
+        && !target_ids.is_empty()
+        && !options.force_shared_renderer;
     let renderer_id = if duplicate_renderers {
         apply_duplicate_renderers(
             app,

--- a/src/playlist/engine.rs
+++ b/src/playlist/engine.rs
@@ -6,6 +6,7 @@ use tokio::task::JoinHandle;
 
 use crate::error::Result;
 use crate::playlist::cursor::PlaylistCursor;
+use crate::playlist::shared;
 use crate::playlist::{repo as plrepo, resolve};
 use crate::queue::rotator::{make_handle, RotationConfig, RotationHandle};
 use crate::queue::Mode;
@@ -41,6 +42,7 @@ pub struct DisplayStatus {
 #[derive(Default)]
 pub struct Engine {
     inner: Mutex<HashMap<DisplayId, DisplayRotation>>,
+    shared: shared::Sessions,
 }
 
 impl Engine {
@@ -49,11 +51,14 @@ impl Engine {
     }
 
     pub async fn owned_display_ids(&self) -> Vec<DisplayId> {
-        self.inner.lock().await.keys().copied().collect()
+        let mut ids = self.inner.lock().await.keys().copied().collect::<Vec<_>>();
+        ids.extend(self.shared.owned_display_ids().await);
+        ids
     }
 
     pub async fn is_owned(&self, display_id: DisplayId) -> bool {
         self.inner.lock().await.contains_key(&display_id)
+            || self.shared.is_owned(display_id).await
     }
 
     pub async fn activate(
@@ -110,6 +115,34 @@ impl Engine {
         } else {
             display_ids.to_vec()
         };
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        if targets.len() >= 2 {
+            for &did in &targets {
+                app.playlists.inner.lock().await.remove(&did);
+            }
+            app.playlists
+                .shared
+                .activate(
+                    app,
+                    &targets,
+                    playlist_id,
+                    mode,
+                    interval,
+                    items,
+                    resume,
+                    first_frame_timeout,
+                )
+                .await?;
+            for &did in &targets {
+                persist_assignment(app, did, Some(playlist_id)).await;
+            }
+            app.events
+                .publish(crate::events::GlobalEvent::PlaylistChanged);
+            return Ok(());
+        }
 
         // Shared across all targets so displays activated together shuffle in sync.
         let seed = std::time::SystemTime::now()
@@ -118,6 +151,7 @@ impl Engine {
             .unwrap_or(1)
             .max(1);
 
+        app.playlists.shared.release(&targets).await;
         for did in targets {
             Self::activate_one(
                 app,
@@ -136,6 +170,27 @@ impl Engine {
         app.events
             .publish(crate::events::GlobalEvent::PlaylistChanged);
         Ok(())
+    }
+
+    pub async fn attach_shared(
+        app: &Arc<AppState>,
+        display_id: DisplayId,
+        playlist_id: i64,
+    ) -> Result<bool> {
+        if app.playlists.is_owned(display_id).await {
+            return Ok(true);
+        }
+        let attached = app
+            .playlists
+            .shared
+            .attach(app, display_id, playlist_id)
+            .await?;
+        if attached {
+            persist_assignment(app, display_id, Some(playlist_id)).await;
+            app.events
+                .publish(crate::events::GlobalEvent::PlaylistChanged);
+        }
+        Ok(attached)
     }
 
     async fn activate_one(
@@ -197,11 +252,13 @@ impl Engine {
             }
         }
 
-        let task = tokio::spawn(run_display_rotator(
+        let members = Arc::new(Mutex::new(vec![display_id]));
+        let task = tokio::spawn(run_playlist_rotator(
             app.clone(),
-            display_id,
             cursor.clone(),
             deadline.clone(),
+            members,
+            false,
             rx,
             app.shutdown_subscribe(),
         ));
@@ -225,9 +282,10 @@ impl Engine {
         } else {
             display_ids.to_vec()
         };
-        for did in targets {
-            app.playlists.inner.lock().await.remove(&did);
-            persist_assignment(app, did, None).await;
+        app.playlists.shared.release(&targets).await;
+        for did in &targets {
+            app.playlists.inner.lock().await.remove(did);
+            persist_assignment(app, *did, None).await;
         }
         app.events
             .publish(crate::events::GlobalEvent::PlaylistChanged);
@@ -235,6 +293,9 @@ impl Engine {
     }
 
     pub async fn step(app: &Arc<AppState>, display_id: DisplayId, delta: i32) -> Result<()> {
+        if app.playlists.shared.step(app, display_id, delta).await? {
+            return Ok(());
+        }
         let cursor = {
             let map = app.playlists.inner.lock().await;
             map.get(&display_id).map(|r| r.cursor.clone())
@@ -254,6 +315,14 @@ impl Engine {
     }
 
     pub async fn jump_to(app: &Arc<AppState>, playlist_id: i64, entry_id: &str) -> Result<()> {
+        if app
+            .playlists
+            .shared
+            .jump_to(app, playlist_id, entry_id)
+            .await?
+        {
+            return Ok(());
+        }
         let displays: Vec<(DisplayId, Arc<Mutex<PlaylistCursor>>)> = {
             let map = app.playlists.inner.lock().await;
             map.iter()
@@ -316,14 +385,20 @@ impl Engine {
                 remaining_secs,
             });
         }
+        out.extend(self.shared.status().await);
         out
     }
 
     pub async fn drop_display(&self, display_id: DisplayId) {
+        self.shared.drop_display(display_id).await;
         self.inner.lock().await.remove(&display_id);
     }
 
     pub async fn deactivate_for_playlist(app: &Arc<AppState>, playlist_id: i64) {
+        let shared_members = app.playlists.shared.deactivate_playlist(playlist_id).await;
+        for did in &shared_members {
+            persist_assignment(app, *did, None).await;
+        }
         let owned: Vec<DisplayId> = {
             let map = app.playlists.inner.lock().await;
             map.iter()
@@ -331,13 +406,48 @@ impl Engine {
                 .map(|(d, _)| *d)
                 .collect()
         };
-        if owned.is_empty() {
+        if owned.is_empty() && shared_members.is_empty() {
             return;
         }
-        let _ = Self::deactivate(app, &owned).await;
+        if !owned.is_empty() {
+            let _ = Self::deactivate(app, &owned).await;
+        } else if !shared_members.is_empty() {
+            app.events
+                .publish(crate::events::GlobalEvent::PlaylistChanged);
+        }
     }
 
     pub async fn rebuild_for_playlist(app: &Arc<AppState>, playlist_id: i64) {
+        let pl = match plrepo::get(&app.db, playlist_id).await {
+            Ok(Some(p)) => p,
+            _ => return,
+        };
+        let mode: Mode = pl.mode.into();
+        let interval = pl.interval_secs as u32;
+        let items = resolve::resolve(app, playlist_id).await.unwrap_or_default();
+
+        match app
+            .playlists
+            .shared
+            .rebuild(app, playlist_id, mode, interval, items.clone())
+            .await
+        {
+            Ok(None) => {}
+            Ok(Some(cleared)) if !cleared.is_empty() => {
+                for did in cleared {
+                    persist_assignment(app, did, None).await;
+                }
+                app.events
+                    .publish(crate::events::GlobalEvent::PlaylistChanged);
+                return;
+            }
+            Ok(Some(_)) => return,
+            Err(e) => {
+                log::warn!("shared playlist rebuild {playlist_id} failed: {e:#}");
+                return;
+            }
+        }
+
         type Bound = (DisplayId, Arc<Mutex<PlaylistCursor>>, RotationHandle);
         let affected: Vec<Bound> = {
             let map = app.playlists.inner.lock().await;
@@ -349,14 +459,6 @@ impl Engine {
         if affected.is_empty() {
             return;
         }
-
-        let pl = match plrepo::get(&app.db, playlist_id).await {
-            Ok(Some(p)) => p,
-            _ => return,
-        };
-        let mode: Mode = pl.mode.into();
-        let interval = pl.interval_secs as u32;
-        let items = resolve::resolve(app, playlist_id).await.unwrap_or_default();
 
         if items.is_empty() {
             let ids: Vec<DisplayId> = affected.iter().map(|(d, _, _)| *d).collect();
@@ -387,6 +489,9 @@ impl Engine {
     }
 
     pub async fn set_interval_for_playlist(app: &Arc<AppState>, playlist_id: i64, secs: u32) {
+        if app.playlists.shared.set_interval(playlist_id, secs).await {
+            return;
+        }
         let map = app.playlists.inner.lock().await;
         for (_, r) in map.iter() {
             if r.playlist_id == playlist_id {
@@ -396,11 +501,12 @@ impl Engine {
     }
 }
 
-async fn run_display_rotator(
+pub(crate) async fn run_playlist_rotator(
     app: Arc<AppState>,
-    display_id: DisplayId,
     cursor: Arc<Mutex<PlaylistCursor>>,
     deadline: Arc<std::sync::Mutex<Option<std::time::Instant>>>,
+    targets: Arc<Mutex<Vec<DisplayId>>>,
+    shared_renderer: bool,
     mut rx: tokio::sync::watch::Receiver<RotationConfig>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) {
@@ -420,12 +526,24 @@ async fn run_display_rotator(
             tokio::select! {
                 _ = tokio::time::sleep(dur) => {
                     if rx.borrow().interval_secs == 0 { continue; }
+                    let members = targets.lock().await.clone();
+                    if members.is_empty() {
+                        continue;
+                    }
                     let next = cursor.lock().await.next(1);
                     if let Some(id) = next {
-                        if let Err(e) =
-                            crate::control::apply_wallpaper_to_displays(&app, &id, &[display_id]).await
-                        {
-                            log::warn!("playlist rotator display={display_id} apply failed: {e:#}");
+                        let result = if shared_renderer {
+                            crate::control::apply_wallpaper_shared_to_displays(
+                                &app, &id, &members, None,
+                            )
+                            .await
+                        } else {
+                            crate::control::apply_wallpaper_to_displays(&app, &id, &members).await
+                        };
+                        if let Err(e) = result {
+                            log::warn!(
+                                "playlist rotator displays={members:?} apply failed: {e:#}"
+                            );
                         }
                     }
                 }
@@ -450,7 +568,10 @@ async fn persist_assignment(app: &Arc<AppState>, display_id: DisplayId, playlist
     app.settings.flush_now().await;
 }
 
-async fn display_settings_key(app: &Arc<AppState>, display_id: DisplayId) -> Option<String> {
+pub(crate) async fn display_settings_key(
+    app: &Arc<AppState>,
+    display_id: DisplayId,
+) -> Option<String> {
     app.router
         .snapshot_displays()
         .await

--- a/src/playlist/engine.rs
+++ b/src/playlist/engine.rs
@@ -111,6 +111,13 @@ impl Engine {
             display_ids.to_vec()
         };
 
+        // Shared across all targets so displays activated together shuffle in sync.
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(1)
+            .max(1);
+
         for did in targets {
             Self::activate_one(
                 app,
@@ -121,6 +128,7 @@ impl Engine {
                 items.clone(),
                 resume,
                 first_frame_timeout,
+                seed,
             )
             .await?;
             persist_assignment(app, did, Some(playlist_id)).await;
@@ -139,15 +147,11 @@ impl Engine {
         items: Vec<String>,
         resume: bool,
         first_frame_timeout: Option<std::time::Duration>,
+        seed: u64,
     ) -> Result<()> {
         {
             app.playlists.inner.lock().await.remove(&display_id);
         }
-        let entropy = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(1);
-        let seed = (entropy ^ display_id.wrapping_mul(0x9E3779B97F4A7C15)).max(1);
         let resume_id = if resume && mode != Mode::Random {
             match display_settings_key(app, display_id).await {
                 Some(key) => app

--- a/src/playlist/engine.rs
+++ b/src/playlist/engine.rs
@@ -151,7 +151,6 @@ impl Engine {
             .unwrap_or(1)
             .max(1);
 
-        app.playlists.shared.release(&targets).await;
         for did in targets {
             Self::activate_one(
                 app,
@@ -204,9 +203,6 @@ impl Engine {
         first_frame_timeout: Option<std::time::Duration>,
         seed: u64,
     ) -> Result<()> {
-        {
-            app.playlists.inner.lock().await.remove(&display_id);
-        }
         let resume_id = if resume && mode != Mode::Random {
             match display_settings_key(app, display_id).await {
                 Some(key) => app
@@ -219,11 +215,11 @@ impl Engine {
         } else {
             None
         };
+
         let cursor = Arc::new(Mutex::new(PlaylistCursor::new(items, mode, seed)));
         let (handle, rx) = make_handle();
         handle.set_interval(interval);
         let deadline = Arc::new(std::sync::Mutex::new(None));
-
         let first = {
             let mut c = cursor.lock().await;
             match resume_id {
@@ -234,23 +230,6 @@ impl Engine {
                 None => c.first(),
             }
         };
-        if let Some(id) = first {
-            match first_frame_timeout {
-                Some(timeout) => {
-                    crate::control::apply_wallpaper_to_displays_with_first_frame_timeout(
-                        app,
-                        &id,
-                        &[display_id],
-                        timeout,
-                    )
-                    .await?;
-                }
-                None => {
-                    let _ =
-                        crate::control::apply_wallpaper_to_displays(app, &id, &[display_id]).await;
-                }
-            }
-        }
 
         let members = Arc::new(Mutex::new(vec![display_id]));
         let task = tokio::spawn(run_playlist_rotator(
@@ -262,17 +241,44 @@ impl Engine {
             rx,
             app.shutdown_subscribe(),
         ));
+        {
+            let mut map = app.playlists.inner.lock().await;
+            map.remove(&display_id);
+            map.insert(
+                display_id,
+                DisplayRotation {
+                    playlist_id,
+                    cursor,
+                    handle,
+                    deadline,
+                    task,
+                },
+            );
+        }
+        app.playlists.shared.release(&[display_id]).await;
 
-        app.playlists.inner.lock().await.insert(
-            display_id,
-            DisplayRotation {
-                playlist_id,
-                cursor,
-                handle,
-                deadline,
-                task,
-            },
-        );
+        if let Some(id) = first {
+            match first_frame_timeout {
+                Some(timeout) => {
+                    if let Err(e) =
+                        crate::control::apply_wallpaper_to_displays_with_first_frame_timeout(
+                            app,
+                            &id,
+                            &[display_id],
+                            timeout,
+                        )
+                        .await
+                    {
+                        app.playlists.inner.lock().await.remove(&display_id);
+                        return Err(e);
+                    }
+                }
+                None => {
+                    let _ =
+                        crate::control::apply_wallpaper_to_displays(app, &id, &[display_id]).await;
+                }
+            }
+        }
         Ok(())
     }
 

--- a/src/playlist/engine.rs
+++ b/src/playlist/engine.rs
@@ -585,3 +585,74 @@ pub(crate) async fn display_settings_key(
         .find(|d| d.id == display_id)
         .map(|d| d.instance_id.unwrap_or(d.name))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::queue::Mode;
+
+    #[tokio::test]
+    async fn is_owned_true_for_shared_or_inner() {
+        let engine = Engine::new();
+        assert!(!engine.is_owned(1).await);
+
+        engine
+            .shared
+            .seed_for_test(9, &[1], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        assert!(engine.is_owned(1).await);
+        assert!(!engine.is_owned(2).await);
+
+        let cursor = Arc::new(Mutex::new(PlaylistCursor::new(
+            vec!["a".into()],
+            Mode::Sequential,
+            1,
+        )));
+        let (handle, _rx) = make_handle();
+        let task = tokio::spawn(async {});
+        engine.inner.lock().await.insert(
+            2,
+            DisplayRotation {
+                playlist_id: 9,
+                cursor,
+                handle,
+                deadline: Arc::new(std::sync::Mutex::new(None)),
+                task,
+            },
+        );
+        assert!(engine.is_owned(2).await);
+    }
+
+    #[tokio::test]
+    async fn claim_inner_before_shared_release_keeps_owned() {
+        let engine = Engine::new();
+        engine
+            .shared
+            .seed_for_test(3, &[10], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        assert!(engine.is_owned(10).await);
+
+        let cursor = Arc::new(Mutex::new(PlaylistCursor::new(
+            vec!["b".into()],
+            Mode::Sequential,
+            1,
+        )));
+        let (handle, _rx) = make_handle();
+        let task = tokio::spawn(async {});
+        engine.inner.lock().await.insert(
+            10,
+            DisplayRotation {
+                playlist_id: 4,
+                cursor,
+                handle,
+                deadline: Arc::new(std::sync::Mutex::new(None)),
+                task,
+            },
+        );
+        engine.shared.release(&[10]).await;
+
+        assert!(engine.is_owned(10).await);
+        assert!(engine.inner.lock().await.contains_key(&10));
+        assert!(!engine.shared.is_owned(10).await);
+    }
+}

--- a/src/playlist/mod.rs
+++ b/src/playlist/mod.rs
@@ -3,3 +3,4 @@ pub mod engine;
 pub mod repo;
 pub mod resolve;
 pub mod restore;
+pub mod shared;

--- a/src/playlist/restore.rs
+++ b/src/playlist/restore.rs
@@ -1,10 +1,14 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::playlist::engine::Engine;
 use crate::routing::RouterEvent;
 use crate::scheduler::DisplayId;
 use crate::AppState;
+
+const SETTLE: Duration = Duration::from_secs(2);
+const IDLE_PARK: Duration = Duration::from_secs(3600);
 
 fn resolve_pid(app: &Arc<AppState>, key: &str) -> Option<i64> {
     app.settings
@@ -13,9 +17,11 @@ fn resolve_pid(app: &Arc<AppState>, key: &str) -> Option<i64> {
         .or_else(|| app.settings.global().auto_attach_playlist_id)
 }
 
-// Displays resolving to the same playlist are activated together so shuffle stays in sync.
 async fn activate_groups(app: &Arc<AppState>, groups: HashMap<i64, Vec<DisplayId>>) {
     for (pid, display_ids) in groups {
+        if display_ids.is_empty() {
+            continue;
+        }
         if let Err(e) = Engine::activate_resuming_with_first_frame_timeout(
             app,
             &display_ids,
@@ -27,6 +33,76 @@ async fn activate_groups(app: &Arc<AppState>, groups: HashMap<i64, Vec<DisplayId
             log::warn!("restore playlist {pid} on displays {display_ids:?} failed: {e:#}");
         }
     }
+}
+
+fn queue_pending(
+    pending: &mut HashMap<i64, (tokio::time::Instant, Vec<DisplayId>)>,
+    pid: i64,
+    display_id: DisplayId,
+    settle: Duration,
+) {
+    let entry = pending
+        .entry(pid)
+        .or_insert_with(|| (tokio::time::Instant::now() + settle, Vec::new()));
+    if !entry.1.contains(&display_id) {
+        entry.1.push(display_id);
+    }
+}
+
+fn remove_pending_display(
+    pending: &mut HashMap<i64, (tokio::time::Instant, Vec<DisplayId>)>,
+    display_id: DisplayId,
+) {
+    pending.retain(|_, (_, ids)| {
+        ids.retain(|d| *d != display_id);
+        !ids.is_empty()
+    });
+}
+
+async fn collect_playlist_targets(app: &Arc<AppState>, pid: i64) -> Vec<DisplayId> {
+    let status = app.playlists.status().await;
+    let owned_other: HashSet<DisplayId> = status
+        .iter()
+        .filter(|s| s.active_id != pid)
+        .map(|s| s.display_id)
+        .collect();
+    let owned_same: HashSet<DisplayId> = status
+        .iter()
+        .filter(|s| s.active_id == pid)
+        .map(|s| s.display_id)
+        .collect();
+
+    let mut out = Vec::new();
+    for d in app.router.snapshot_displays().await {
+        if owned_other.contains(&d.id) {
+            continue;
+        }
+        if owned_same.contains(&d.id) {
+            out.push(d.id);
+            continue;
+        }
+        let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
+        if resolve_pid(app, &key) == Some(pid) {
+            out.push(d.id);
+        }
+    }
+    out
+}
+
+async fn flush_pending(
+    app: &Arc<AppState>,
+    pending: &mut HashMap<i64, (tokio::time::Instant, Vec<DisplayId>)>,
+    due: impl IntoIterator<Item = i64>,
+) {
+    let mut groups = HashMap::new();
+    for pid in due {
+        pending.remove(&pid);
+        let targets = collect_playlist_targets(app, pid).await;
+        if !targets.is_empty() {
+            groups.insert(pid, targets);
+        }
+    }
+    activate_groups(app, groups).await;
 }
 
 pub async fn restore_all(app: &Arc<AppState>) {
@@ -66,8 +142,17 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
         .into_iter()
         .map(|d| d.id)
         .collect();
+    let mut pending: HashMap<i64, (tokio::time::Instant, Vec<DisplayId>)> = HashMap::new();
 
     loop {
+        let next_deadline = pending
+            .values()
+            .map(|(d, _)| *d)
+            .min()
+            .unwrap_or_else(|| tokio::time::Instant::now() + IDLE_PARK);
+        let sleep = tokio::time::sleep_until(next_deadline);
+        tokio::pin!(sleep);
+
         tokio::select! {
             ev = rx.recv() => {
                 match ev {
@@ -82,50 +167,53 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
                         } else {
                             app.settings.display_prefs(&key).and_then(|p| p.active_playlist_id)
                         };
-                        if let Some(pid) = pid {
-                            match Engine::attach_shared(&app, s.id, pid).await {
-                                Ok(true) => {}
-                                Ok(false) => {
-                                    if let Err(e) =
-                                        Engine::activate_resuming_with_first_frame_timeout(
-                                            &app,
-                                            &[s.id],
-                                            pid,
-                                            crate::control::APPLY_FIRST_FRAME_TIMEOUT,
-                                        )
-                                        .await
-                                    {
-                                        log::warn!("hotplug activate playlist {pid} failed: {e:#}");
-                                    }
-                                }
-                                Err(e) => {
-                                    log::warn!("hotplug attach playlist {pid} failed: {e:#}");
-                                }
+                        let Some(pid) = pid else { continue };
+                        match Engine::attach_shared(&app, s.id, pid).await {
+                            Ok(true) => {}
+                            Ok(false) => queue_pending(&mut pending, pid, s.id, SETTLE),
+                            Err(e) => {
+                                log::warn!("hotplug attach playlist {pid} failed: {e:#}");
                             }
                         }
                     }
                     Ok(RouterEvent::DisplayRemoved(id)) => {
                         app.playlists.drop_display(id).await;
                         known.remove(&id);
+                        remove_pending_display(&mut pending, id);
                     }
                     Ok(_) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         log::warn!("playlist hotplug watcher lagged {n} events; re-snapshotting");
-                        let displays = app.router.snapshot_displays().await;
-                        let mut groups: HashMap<i64, Vec<DisplayId>> = HashMap::new();
-                        for d in displays {
+                        pending.clear();
+                        known.clear();
+                        let mut pids = HashSet::new();
+                        for d in app.router.snapshot_displays().await {
                             known.insert(d.id);
-                            if app.playlists.is_owned(d.id).await {
-                                continue;
-                            }
                             let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
                             if let Some(pid) = resolve_pid(&app, &key) {
-                                groups.entry(pid).or_default().push(d.id);
+                                pids.insert(pid);
+                            }
+                        }
+                        let mut groups = HashMap::new();
+                        for pid in pids {
+                            let targets = collect_playlist_targets(&app, pid).await;
+                            if !targets.is_empty() {
+                                groups.insert(pid, targets);
                             }
                         }
                         activate_groups(&app, groups).await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            _ = &mut sleep => {
+                let now = tokio::time::Instant::now();
+                let due: Vec<i64> = pending
+                    .iter()
+                    .filter_map(|(pid, (d, _))| (*d <= now).then_some(*pid))
+                    .collect();
+                if !due.is_empty() {
+                    flush_pending(&app, &mut pending, due).await;
                 }
             }
             changed = shutdown.changed() => {

--- a/src/playlist/restore.rs
+++ b/src/playlist/restore.rs
@@ -83,15 +83,24 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
                             app.settings.display_prefs(&key).and_then(|p| p.active_playlist_id)
                         };
                         if let Some(pid) = pid {
-                            if let Err(e) = Engine::activate_resuming_with_first_frame_timeout(
-                                &app,
-                                &[s.id],
-                                pid,
-                                crate::control::APPLY_FIRST_FRAME_TIMEOUT,
-                            )
-                            .await
-                            {
-                                log::warn!("hotplug activate playlist {pid} failed: {e:#}");
+                            match Engine::attach_shared(&app, s.id, pid).await {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    if let Err(e) =
+                                        Engine::activate_resuming_with_first_frame_timeout(
+                                            &app,
+                                            &[s.id],
+                                            pid,
+                                            crate::control::APPLY_FIRST_FRAME_TIMEOUT,
+                                        )
+                                        .await
+                                    {
+                                        log::warn!("hotplug activate playlist {pid} failed: {e:#}");
+                                    }
+                                }
+                                Err(e) => {
+                                    log::warn!("hotplug attach playlist {pid} failed: {e:#}");
+                                }
                             }
                         }
                     }

--- a/src/playlist/restore.rs
+++ b/src/playlist/restore.rs
@@ -10,11 +10,27 @@ use crate::AppState;
 const SETTLE: Duration = Duration::from_secs(2);
 const IDLE_PARK: Duration = Duration::from_secs(3600);
 
+fn resolve_playlist_id(active: Option<i64>, auto_attach: Option<i64>) -> Option<i64> {
+    active.or(auto_attach)
+}
+
 fn resolve_pid(app: &Arc<AppState>, key: &str) -> Option<i64> {
-    app.settings
-        .display_prefs(key)
-        .and_then(|p| p.active_playlist_id)
-        .or_else(|| app.settings.global().auto_attach_playlist_id)
+    resolve_playlist_id(
+        app.settings
+            .display_prefs(key)
+            .and_then(|p| p.active_playlist_id),
+        app.settings.global().auto_attach_playlist_id,
+    )
+}
+
+fn group_displays_by_playlist(
+    entries: impl IntoIterator<Item = (DisplayId, i64)>,
+) -> HashMap<i64, Vec<DisplayId>> {
+    let mut groups: HashMap<i64, Vec<DisplayId>> = HashMap::new();
+    for (display_id, pid) in entries {
+        groups.entry(pid).or_default().push(display_id);
+    }
+    groups
 }
 
 async fn activate_groups(app: &Arc<AppState>, groups: HashMap<i64, Vec<DisplayId>>) {
@@ -107,14 +123,11 @@ async fn flush_pending(
 
 pub async fn restore_all(app: &Arc<AppState>) {
     let displays = app.router.snapshot_displays().await;
-    let mut groups: HashMap<i64, Vec<DisplayId>> = HashMap::new();
-    for d in displays {
+    let entries = displays.into_iter().filter_map(|d| {
         let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
-        if let Some(pid) = resolve_pid(app, &key) {
-            groups.entry(pid).or_default().push(d.id);
-        }
-    }
-    activate_groups(app, groups).await;
+        resolve_pid(app, &key).map(|pid| (d.id, pid))
+    });
+    activate_groups(app, group_displays_by_playlist(entries)).await;
 }
 
 pub async fn watch_hotplug(app: Arc<AppState>) {
@@ -220,5 +233,61 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
                 if changed.is_err() || *shutdown.borrow() { break; }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn queue_pending_coalesces_same_playlist() {
+        let mut pending = HashMap::new();
+        let settle = Duration::from_secs(2);
+        queue_pending(&mut pending, 7, 1, settle);
+        queue_pending(&mut pending, 7, 2, settle);
+        queue_pending(&mut pending, 7, 1, settle);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending.get(&7).unwrap().1, vec![1, 2]);
+    }
+
+    #[test]
+    fn queue_pending_keeps_separate_playlists() {
+        let mut pending = HashMap::new();
+        let settle = Duration::from_millis(10);
+        queue_pending(&mut pending, 1, 10, settle);
+        queue_pending(&mut pending, 2, 20, settle);
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending.get(&1).unwrap().1, vec![10]);
+        assert_eq!(pending.get(&2).unwrap().1, vec![20]);
+    }
+
+    #[test]
+    fn remove_pending_display_drops_empty_entries() {
+        let mut pending = HashMap::new();
+        let settle = Duration::from_secs(1);
+        queue_pending(&mut pending, 1, 10, settle);
+        queue_pending(&mut pending, 1, 11, settle);
+        queue_pending(&mut pending, 2, 20, settle);
+        remove_pending_display(&mut pending, 10);
+        assert_eq!(pending.get(&1).unwrap().1, vec![11]);
+        remove_pending_display(&mut pending, 11);
+        assert!(!pending.contains_key(&1));
+        assert_eq!(pending.get(&2).unwrap().1, vec![20]);
+    }
+
+    #[test]
+    fn resolve_playlist_id_prefers_active_then_auto_attach() {
+        assert_eq!(resolve_playlist_id(Some(3), Some(9)), Some(3));
+        assert_eq!(resolve_playlist_id(None, Some(9)), Some(9));
+        assert_eq!(resolve_playlist_id(None, None), None);
+    }
+
+    #[test]
+    fn group_displays_by_playlist_merges_same_pid() {
+        let groups = group_displays_by_playlist([(1, 42), (2, 42), (3, 7)]);
+        assert_eq!(groups.get(&42).unwrap(), &vec![1, 2]);
+        assert_eq!(groups.get(&7).unwrap(), &vec![3]);
     }
 }

--- a/src/playlist/restore.rs
+++ b/src/playlist/restore.rs
@@ -1,7 +1,9 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::playlist::engine::Engine;
 use crate::routing::RouterEvent;
+use crate::scheduler::DisplayId;
 use crate::AppState;
 
 fn resolve_pid(app: &Arc<AppState>, key: &str) -> Option<i64> {
@@ -11,24 +13,32 @@ fn resolve_pid(app: &Arc<AppState>, key: &str) -> Option<i64> {
         .or_else(|| app.settings.global().auto_attach_playlist_id)
 }
 
-pub async fn restore_all(app: &Arc<AppState>) {
-    let displays = app.router.snapshot_displays().await;
-    for d in displays {
-        let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
-        let pid = resolve_pid(app, &key);
-        if let Some(pid) = pid {
-            if let Err(e) = Engine::activate_resuming_with_first_frame_timeout(
-                app,
-                &[d.id],
-                pid,
-                crate::control::APPLY_FIRST_FRAME_TIMEOUT,
-            )
-            .await
-            {
-                log::warn!("restore playlist {pid} on display {} failed: {e:#}", d.id);
-            }
+// Displays resolving to the same playlist are activated together so shuffle stays in sync.
+async fn activate_groups(app: &Arc<AppState>, groups: HashMap<i64, Vec<DisplayId>>) {
+    for (pid, display_ids) in groups {
+        if let Err(e) = Engine::activate_resuming_with_first_frame_timeout(
+            app,
+            &display_ids,
+            pid,
+            crate::control::APPLY_FIRST_FRAME_TIMEOUT,
+        )
+        .await
+        {
+            log::warn!("restore playlist {pid} on displays {display_ids:?} failed: {e:#}");
         }
     }
+}
+
+pub async fn restore_all(app: &Arc<AppState>) {
+    let displays = app.router.snapshot_displays().await;
+    let mut groups: HashMap<i64, Vec<DisplayId>> = HashMap::new();
+    for d in displays {
+        let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
+        if let Some(pid) = resolve_pid(app, &key) {
+            groups.entry(pid).or_default().push(d.id);
+        }
+    }
+    activate_groups(app, groups).await;
 }
 
 pub async fn watch_hotplug(app: Arc<AppState>) {
@@ -48,16 +58,31 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
     }
 
     restore_all(&app).await;
+
+    let mut known: HashSet<DisplayId> = app
+        .router
+        .snapshot_displays()
+        .await
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
+
     loop {
         tokio::select! {
             ev = rx.recv() => {
                 match ev {
                     Ok(RouterEvent::DisplayUpsert(s)) => {
                         let key = s.instance_id.clone().unwrap_or_else(|| s.name.clone());
+                        let is_new = known.insert(s.id);
                         if app.playlists.is_owned(s.id).await {
                             continue;
                         }
-                        if let Some(pid) = resolve_pid(&app, &key) {
+                        let pid = if is_new {
+                            resolve_pid(&app, &key)
+                        } else {
+                            app.settings.display_prefs(&key).and_then(|p| p.active_playlist_id)
+                        };
+                        if let Some(pid) = pid {
                             if let Err(e) = Engine::activate_resuming_with_first_frame_timeout(
                                 &app,
                                 &[s.id],
@@ -72,30 +97,24 @@ pub async fn watch_hotplug(app: Arc<AppState>) {
                     }
                     Ok(RouterEvent::DisplayRemoved(id)) => {
                         app.playlists.drop_display(id).await;
+                        known.remove(&id);
                     }
                     Ok(_) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         log::warn!("playlist hotplug watcher lagged {n} events; re-snapshotting");
                         let displays = app.router.snapshot_displays().await;
+                        let mut groups: HashMap<i64, Vec<DisplayId>> = HashMap::new();
                         for d in displays {
+                            known.insert(d.id);
                             if app.playlists.is_owned(d.id).await {
                                 continue;
                             }
                             let key = d.instance_id.clone().unwrap_or_else(|| d.name.clone());
                             if let Some(pid) = resolve_pid(&app, &key) {
-                                if let Err(e) =
-                                    Engine::activate_resuming_with_first_frame_timeout(
-                                        &app,
-                                        &[d.id],
-                                        pid,
-                                        crate::control::APPLY_FIRST_FRAME_TIMEOUT,
-                                    )
-                                    .await
-                                {
-                                    log::warn!("lag-recover activate playlist {pid} failed: {e:#}");
-                                }
+                                groups.entry(pid).or_default().push(d.id);
                             }
                         }
+                        activate_groups(&app, groups).await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }

--- a/src/playlist/shared.rs
+++ b/src/playlist/shared.rs
@@ -150,15 +150,10 @@ impl Sessions {
         display_id: DisplayId,
         playlist_id: i64,
     ) -> Result<bool> {
-        if self.is_owned(display_id).await {
-            return Ok(true);
-        }
-        let session = {
-            let by_playlist = self.by_playlist.lock().await;
-            by_playlist.get(&playlist_id).cloned()
-        };
-        let Some(session) = session else {
-            return Ok(false);
+        let session = match self.attach_start(display_id, playlist_id).await {
+            AttachStart::AlreadyOwned => return Ok(true),
+            AttachStart::NoSession => return Ok(false),
+            AttachStart::Session(session) => session,
         };
 
         let current = session.cursor.lock().await.current.clone();
@@ -315,9 +310,7 @@ impl Sessions {
             return Ok(None);
         };
         if items.is_empty() {
-            let members = session.members.lock().await.clone();
-            self.release(&members).await;
-            return Ok(Some(members));
+            return Ok(Some(self.deactivate_playlist(playlist_id).await));
         }
 
         let (apply_id, need_apply) = {
@@ -357,5 +350,177 @@ impl Sessions {
     async fn session_for_display(&self, display_id: DisplayId) -> Option<Arc<SharedSession>> {
         let pid = self.by_display.lock().await.get(&display_id).copied()?;
         self.by_playlist.lock().await.get(&pid).cloned()
+    }
+
+    async fn attach_start(&self, display_id: DisplayId, playlist_id: i64) -> AttachStart {
+        if self.is_owned(display_id).await {
+            return AttachStart::AlreadyOwned;
+        }
+        let session = {
+            let by_playlist = self.by_playlist.lock().await;
+            by_playlist.get(&playlist_id).cloned()
+        };
+        match session {
+            Some(session) => AttachStart::Session(session),
+            None => AttachStart::NoSession,
+        }
+    }
+}
+
+enum AttachStart {
+    AlreadyOwned,
+    NoSession,
+    Session(Arc<SharedSession>),
+}
+
+#[cfg(test)]
+impl Sessions {
+    pub(crate) async fn seed_for_test(
+        &self,
+        playlist_id: i64,
+        members: &[DisplayId],
+        items: Vec<String>,
+        current: Option<String>,
+        interval: u32,
+    ) {
+        let mut cursor = PlaylistCursor::new(items, Mode::Sequential, 1);
+        if let Some(id) = current.as_ref() {
+            cursor.set_current(id);
+        } else {
+            cursor.first();
+        }
+        let (handle, rx) = make_handle();
+        handle.set_interval(interval);
+        let task = tokio::spawn(async move {
+            let _rx = rx;
+            std::future::pending::<()>().await
+        });
+        let session = Arc::new(SharedSession {
+            playlist_id,
+            cursor: Arc::new(Mutex::new(cursor)),
+            handle,
+            deadline: Arc::new(std::sync::Mutex::new(None)),
+            members: Arc::new(Mutex::new(members.to_vec())),
+            task,
+        });
+        self.by_playlist
+            .lock()
+            .await
+            .insert(playlist_id, Arc::clone(&session));
+        let mut by_display = self.by_display.lock().await;
+        for &did in members {
+            by_display.insert(did, playlist_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn is_owned_and_release_last_member_drops_session() {
+        let sessions = Sessions::default();
+        sessions
+            .seed_for_test(1, &[10, 20], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        assert!(sessions.is_owned(10).await);
+        assert!(sessions.is_owned(20).await);
+        sessions.release(&[10]).await;
+        assert!(!sessions.is_owned(10).await);
+        assert!(sessions.is_owned(20).await);
+        assert!(sessions.by_playlist.lock().await.contains_key(&1));
+        sessions.release(&[20]).await;
+        assert!(!sessions.is_owned(20).await);
+        assert!(sessions.by_playlist.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn attach_returns_false_without_session() {
+        let sessions = Sessions::default();
+        assert!(matches!(
+            sessions.attach_start(5, 99).await,
+            AttachStart::NoSession
+        ));
+    }
+
+    #[tokio::test]
+    async fn attach_noops_when_already_owned() {
+        let sessions = Sessions::default();
+        sessions
+            .seed_for_test(1, &[5], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        assert!(matches!(
+            sessions.attach_start(5, 1).await,
+            AttachStart::AlreadyOwned
+        ));
+    }
+
+    #[tokio::test]
+    async fn deactivate_playlist_returns_members() {
+        let sessions = Sessions::default();
+        sessions
+            .seed_for_test(3, &[1, 2], vec!["a".into()], Some("a".into()), 10)
+            .await;
+        let members = sessions.deactivate_playlist(3).await;
+        assert_eq!(members, vec![1, 2]);
+        assert!(!sessions.is_owned(1).await);
+        assert!(!sessions.is_owned(2).await);
+        assert!(sessions.deactivate_playlist(3).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_fans_out_same_cursor_to_all_members() {
+        let sessions = Sessions::default();
+        sessions
+            .seed_for_test(
+                8,
+                &[100, 200],
+                vec!["a".into(), "b".into()],
+                Some("b".into()),
+                45,
+            )
+            .await;
+        let status = sessions.status().await;
+        assert_eq!(status.len(), 2);
+        for s in &status {
+            assert_eq!(s.active_id, 8);
+            assert_eq!(s.current_id.as_deref(), Some("b"));
+            assert_eq!(s.position, 1);
+            assert_eq!(s.count, 2);
+            assert_eq!(s.interval_secs, 45);
+        }
+        let ids: Vec<_> = status.iter().map(|s| s.display_id).collect();
+        assert!(ids.contains(&100));
+        assert!(ids.contains(&200));
+    }
+
+    #[tokio::test]
+    async fn rebuild_empty_items_releases_session() {
+        let sessions = Sessions::default();
+        sessions
+            .seed_for_test(4, &[7, 8], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        let exists = sessions.by_playlist.lock().await.contains_key(&4);
+        assert!(exists);
+        let members = sessions.deactivate_playlist(4).await;
+        assert_eq!(members, vec![7, 8]);
+        assert!(sessions.by_playlist.lock().await.is_empty());
+        assert!(matches!(
+            sessions.attach_start(7, 4).await,
+            AttachStart::NoSession
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_interval_updates_existing_session() {
+        let sessions = Sessions::default();
+        assert!(!sessions.set_interval(1, 60).await);
+        sessions
+            .seed_for_test(1, &[9], vec!["a".into()], Some("a".into()), 30)
+            .await;
+        assert!(sessions.set_interval(1, 60).await);
+        let session = sessions.by_playlist.lock().await.get(&1).cloned().unwrap();
+        assert_eq!(session.handle.interval(), 60);
     }
 }

--- a/src/playlist/shared.rs
+++ b/src/playlist/shared.rs
@@ -1,0 +1,361 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::error::Result;
+use crate::playlist::cursor::PlaylistCursor;
+use crate::playlist::engine::{self, DisplayStatus};
+use crate::queue::rotator::{make_handle, RotationHandle};
+use crate::queue::Mode;
+use crate::scheduler::DisplayId;
+use crate::AppState;
+
+struct SharedSession {
+    playlist_id: i64,
+    cursor: Arc<Mutex<PlaylistCursor>>,
+    handle: RotationHandle,
+    deadline: Arc<std::sync::Mutex<Option<std::time::Instant>>>,
+    members: Arc<Mutex<Vec<DisplayId>>>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for SharedSession {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Default)]
+pub struct Sessions {
+    by_playlist: Mutex<HashMap<i64, Arc<SharedSession>>>,
+    by_display: Mutex<HashMap<DisplayId, i64>>,
+}
+
+impl Sessions {
+    pub async fn owned_display_ids(&self) -> Vec<DisplayId> {
+        self.by_display.lock().await.keys().copied().collect()
+    }
+
+    pub async fn is_owned(&self, display_id: DisplayId) -> bool {
+        self.by_display.lock().await.contains_key(&display_id)
+    }
+
+    pub async fn activate(
+        &self,
+        app: &Arc<AppState>,
+        targets: &[DisplayId],
+        playlist_id: i64,
+        mode: Mode,
+        interval: u32,
+        items: Vec<String>,
+        resume: bool,
+        first_frame_timeout: Option<std::time::Duration>,
+    ) -> Result<()> {
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        self.release(targets).await;
+
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(1)
+            .max(1);
+
+        let resume_id = if resume && mode != Mode::Random {
+            let mut found = None;
+            for &did in targets {
+                let Some(key) = engine::display_settings_key(app, did).await else {
+                    continue;
+                };
+                if let Some(id) = app
+                    .settings
+                    .display_prefs(&key)
+                    .and_then(|p| p.last_wallpaper)
+                    .filter(|id| items.iter().any(|x| x == id))
+                {
+                    found = Some(id);
+                    break;
+                }
+            }
+            found
+        } else {
+            None
+        };
+
+        let cursor = Arc::new(Mutex::new(PlaylistCursor::new(items, mode, seed)));
+        let (handle, rx) = make_handle();
+        handle.set_interval(interval);
+        let deadline = Arc::new(std::sync::Mutex::new(None));
+        let members = Arc::new(Mutex::new(targets.to_vec()));
+
+        let first = {
+            let mut c = cursor.lock().await;
+            match resume_id {
+                Some(id) => {
+                    c.set_current(&id);
+                    Some(id)
+                }
+                None => c.first(),
+            }
+        };
+        if let Some(id) = first {
+            crate::control::apply_wallpaper_shared_to_displays(
+                app,
+                &id,
+                targets,
+                first_frame_timeout,
+            )
+            .await?;
+        }
+
+        let task = tokio::spawn(engine::run_playlist_rotator(
+            app.clone(),
+            cursor.clone(),
+            deadline.clone(),
+            members.clone(),
+            true,
+            rx,
+            app.shutdown_subscribe(),
+        ));
+
+        let session = Arc::new(SharedSession {
+            playlist_id,
+            cursor,
+            handle,
+            deadline,
+            members,
+            task,
+        });
+
+        {
+            let mut by_playlist = self.by_playlist.lock().await;
+            by_playlist.insert(playlist_id, Arc::clone(&session));
+        }
+        {
+            let mut by_display = self.by_display.lock().await;
+            for &did in targets {
+                by_display.insert(did, playlist_id);
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn attach(
+        &self,
+        app: &Arc<AppState>,
+        display_id: DisplayId,
+        playlist_id: i64,
+    ) -> Result<bool> {
+        if self.is_owned(display_id).await {
+            return Ok(true);
+        }
+        let session = {
+            let by_playlist = self.by_playlist.lock().await;
+            by_playlist.get(&playlist_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(false);
+        };
+
+        let current = session.cursor.lock().await.current.clone();
+        if let Some(id) = current {
+            crate::control::apply_wallpaper_shared_to_displays(
+                app,
+                &id,
+                &[display_id],
+                Some(crate::control::APPLY_FIRST_FRAME_TIMEOUT),
+            )
+            .await?;
+        }
+
+        session.members.lock().await.push(display_id);
+        self.by_display
+            .lock()
+            .await
+            .insert(display_id, playlist_id);
+        Ok(true)
+    }
+
+    pub async fn release(&self, display_ids: &[DisplayId]) {
+        let mut by_display = self.by_display.lock().await;
+        let mut touched = Vec::new();
+        for &did in display_ids {
+            if let Some(pid) = by_display.remove(&did) {
+                touched.push((did, pid));
+            }
+        }
+        drop(by_display);
+
+        let mut by_playlist = self.by_playlist.lock().await;
+        for (did, pid) in touched {
+            let Some(session) = by_playlist.get(&pid).cloned() else {
+                continue;
+            };
+            session.members.lock().await.retain(|d| *d != did);
+            if session.members.lock().await.is_empty() {
+                by_playlist.remove(&pid);
+            }
+        }
+    }
+
+    pub async fn step(
+        &self,
+        app: &Arc<AppState>,
+        display_id: DisplayId,
+        delta: i32,
+    ) -> Result<bool> {
+        let session = self.session_for_display(display_id).await;
+        let Some(session) = session else {
+            return Ok(false);
+        };
+        let next = session.cursor.lock().await.next(delta);
+        if let Some(id) = next {
+            let targets = session.members.lock().await.clone();
+            if !targets.is_empty() {
+                crate::control::apply_wallpaper_shared_to_displays(app, &id, &targets, None)
+                    .await?;
+            }
+            session.handle.kick();
+        }
+        Ok(true)
+    }
+
+    pub async fn jump_to(
+        &self,
+        app: &Arc<AppState>,
+        playlist_id: i64,
+        entry_id: &str,
+    ) -> Result<bool> {
+        let session = {
+            let by_playlist = self.by_playlist.lock().await;
+            by_playlist.get(&playlist_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(false);
+        };
+        if !session.cursor.lock().await.set_current(entry_id) {
+            return Ok(true);
+        }
+        let targets = session.members.lock().await.clone();
+        if !targets.is_empty() {
+            crate::control::apply_wallpaper_shared_to_displays(app, entry_id, &targets, None)
+                .await?;
+        }
+        session.handle.kick();
+        Ok(true)
+    }
+
+    pub async fn status(&self) -> Vec<DisplayStatus> {
+        let sessions: Vec<Arc<SharedSession>> = {
+            let by_playlist = self.by_playlist.lock().await;
+            by_playlist.values().cloned().collect()
+        };
+        let now = std::time::Instant::now();
+        let mut out = Vec::new();
+        for session in sessions {
+            let remaining_secs = match *session.deadline.lock().unwrap() {
+                Some(t) => t.saturating_duration_since(now).as_secs() as u32,
+                None => 0,
+            };
+            let interval_secs = session.handle.interval();
+            let (mode, current_id, position, count) = {
+                let c = session.cursor.lock().await;
+                (c.mode, c.current.clone(), c.pos as u32, c.len() as u32)
+            };
+            let members = session.members.lock().await.clone();
+            for did in members {
+                out.push(DisplayStatus {
+                    display_id: did,
+                    active_id: session.playlist_id,
+                    mode,
+                    interval_secs,
+                    current_id: current_id.clone(),
+                    position,
+                    count,
+                    remaining_secs,
+                });
+            }
+        }
+        out
+    }
+
+    pub async fn drop_display(&self, display_id: DisplayId) {
+        self.release(&[display_id]).await;
+    }
+
+    pub async fn deactivate_playlist(&self, playlist_id: i64) -> Vec<DisplayId> {
+        let members = {
+            let by_playlist = self.by_playlist.lock().await;
+            match by_playlist.get(&playlist_id) {
+                Some(s) => s.members.lock().await.clone(),
+                None => return Vec::new(),
+            }
+        };
+        self.release(&members).await;
+        members
+    }
+
+    pub async fn rebuild(
+        &self,
+        app: &Arc<AppState>,
+        playlist_id: i64,
+        mode: Mode,
+        interval: u32,
+        items: Vec<String>,
+    ) -> Result<Option<Vec<DisplayId>>> {
+        let session = {
+            let by_playlist = self.by_playlist.lock().await;
+            by_playlist.get(&playlist_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(None);
+        };
+        if items.is_empty() {
+            let members = session.members.lock().await.clone();
+            self.release(&members).await;
+            return Ok(Some(members));
+        }
+
+        let (apply_id, need_apply) = {
+            let mut c = session.cursor.lock().await;
+            let cur = c.current.clone();
+            c.items = items;
+            c.mode = mode;
+            match cur {
+                Some(id) if c.items.iter().any(|x| x == &id) => {
+                    c.set_current(&id);
+                    (id, false)
+                }
+                _ => (c.first().unwrap_or_default(), true),
+            }
+        };
+        session.handle.set_interval(interval);
+        if need_apply && !apply_id.is_empty() {
+            let targets = session.members.lock().await.clone();
+            if !targets.is_empty() {
+                crate::control::apply_wallpaper_shared_to_displays(app, &apply_id, &targets, None)
+                    .await?;
+            }
+            session.handle.kick();
+        }
+        Ok(Some(Vec::new()))
+    }
+
+    pub async fn set_interval(&self, playlist_id: i64, secs: u32) -> bool {
+        let by_playlist = self.by_playlist.lock().await;
+        let Some(session) = by_playlist.get(&playlist_id) else {
+            return false;
+        };
+        session.handle.set_interval(secs);
+        true
+    }
+
+    async fn session_for_display(&self, display_id: DisplayId) -> Option<Arc<SharedSession>> {
+        let pid = self.by_display.lock().await.get(&display_id).copied()?;
+        self.by_playlist.lock().await.get(&pid).cloned()
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1171,6 +1171,34 @@ duplicate_renderers_for_same_wallpaper = true
     }
 
     #[test]
+    fn auto_attach_playlist_id_roundtrip() {
+        let src = r#"
+[global]
+auto_attach_playlist_id = 42
+"#;
+        let s: Settings = toml::from_str(src).unwrap();
+        assert_eq!(s.global.auto_attach_playlist_id, Some(42));
+        assert!(toml::to_string(&s)
+            .unwrap()
+            .contains("auto_attach_playlist_id = 42"));
+    }
+
+    #[tokio::test]
+    async fn auto_attach_clears_to_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        let store = SettingsStore::load_or_default(path).await;
+        store.update(|s| {
+            s.global.auto_attach_playlist_id = Some(7);
+        });
+        assert_eq!(store.global().auto_attach_playlist_id, Some(7));
+        store.update(|s| {
+            s.global.auto_attach_playlist_id = None;
+        });
+        assert_eq!(store.global().auto_attach_playlist_id, None);
+    }
+
+    #[test]
     fn manual_muted_roundtrip() {
         let src = r#"
 [global]

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -2519,6 +2519,10 @@ async fn dispatch_inner(
             }
 
             let _ = crate::playlist::engine::Engine::deactivate(&state, &r.display_ids).await;
+            state.settings.update(|s| {
+                s.global.auto_attach_playlist_id = None;
+            });
+            state.settings.flush_now().await;
             let res = control::apply_wallpaper_with_options(
                 state,
                 &r.wallpaper_id,

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -2527,6 +2527,7 @@ async fn dispatch_inner(
                     renderer_name: (!r.renderer_name.is_empty()).then_some(r.renderer_name),
                     first_frame_timeout: Some(control::APPLY_FIRST_FRAME_TIMEOUT),
                     require_display: true,
+                    force_shared_renderer: false,
                 },
             )
             .await?;

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -2503,6 +2503,21 @@ async fn dispatch_inner(
         }
 
         Req::WallpaperApply(r) => {
+            let target = (!r.display_ids.is_empty()).then_some(r.display_ids.as_slice());
+            let target_ids = state.router.registered_display_ids(target).await;
+            let mut playlist_running = false;
+            for did in &target_ids {
+                if state.playlists.is_owned(*did).await {
+                    playlist_running = true;
+                    break;
+                }
+            }
+            if playlist_running {
+                return Err(Error::FailedPrecondition(
+                    "pause the playlist on this display before applying a new wallpaper".into(),
+                ));
+            }
+
             let _ = crate::playlist::engine::Engine::deactivate(&state, &r.display_ids).await;
             let res = control::apply_wallpaper_with_options(
                 state,

--- a/ui/qml/page/DisplaysPage.qml
+++ b/ui/qml/page/DisplaysPage.qml
@@ -259,7 +259,7 @@ MD.Page {
 
                             MD.Text {
                                 Layout.fillWidth: true
-                                text: rectItem.d.displayLabel || rectItem.d.name || qsTr("Display %1").arg(rectItem.d.id)
+                                text: rectItem.d.displayLabel || qsTr("Display #%1").arg(rectItem.d.id)
                                 typescale: MD.Token.typescale.title_small
                                 color: rectItem.hasLink ? MD.Token.color.on_primary_container : MD.Token.color.on_surface
                                 horizontalAlignment: Text.AlignHCenter
@@ -359,7 +359,7 @@ MD.Page {
 
                         MD.Text {
                             Layout.fillWidth: true
-                            text: root.selected ? (root.selected.displayLabel || root.selected.name || qsTr("Display %1").arg(root.selected.id)) : ""
+                            text: root.selected ? (root.selected.displayLabel || qsTr("Display #%1").arg(root.selected.id)) : ""
                             typescale: MD.Token.typescale.title_medium
                             color: MD.Token.color.on_surface
                             elide: Text.ElideRight

--- a/ui/qml/page/WallpaperDetailPanel.qml
+++ b/ui/qml/page/WallpaperDetailPanel.qml
@@ -965,7 +965,14 @@ Item {
                         MD.FilterChip {
                             required property var modelData
                             width: Math.min(implicitWidth, 220)
-                            text: (modelData?.displayLabel ?? "") || (modelData?.name ?? "").replace(/^waywallen-[a-z]+-[a-z]+-/, "") || qsTr("Display %1").arg(modelData?.id)
+                            text: {
+                                const alias = modelData?.alias || "";
+                                const name = (modelData?.name || "").replace(/^waywallen-[a-z]+-[a-z]+-/, "");
+                                const base = alias.length > 0 ? alias : name;
+                                if (!base.length)
+                                    return qsTr("Display #%1").arg(modelData?.id);
+                                return base + " (#" + modelData?.id + ")";
+                            }
                             checked: root.applyTargetIds.indexOf(modelData?.id) >= 0
                             onClicked: root.toggleTarget(modelData?.id)
                         }

--- a/ui/qml/page/WallpaperPage.qml
+++ b/ui/qml/page/WallpaperPage.qml
@@ -759,9 +759,30 @@ MD.Page {
         return false;
     }
 
-    function togglePlaylistPlayback(playlist) {
+    function playlistIsSharedActive(playlist) {
+        const displays = root.playlistPlayDisplays || [];
+        if (!playlist || displays.length === 0)
+            return false;
+        return root.playlistDisplayStatuses(playlist).length === displays.length;
+    }
+
+    function togglePlaylistPlayback(playlist, shareAllDisplays) {
+        if (!playlist || playlistPlaybackMutation.querying)
+            return;
+
+        if (shareAllDisplays) {
+            const displayIds = (root.playlistPlayDisplays || []).map(display => display.id);
+            if (displayIds.length === 0)
+                return;
+            if (root.playlistIsSharedActive(playlist))
+                playlistPlaybackMutation.deactivate(displayIds, 0);
+            else
+                playlistPlaybackMutation.activate(playlist.id, displayIds, true);
+            return;
+        }
+
         const display = root.selectedPlaylistDisplay();
-        if (!playlist || !display || playlistPlaybackMutation.querying)
+        if (!display)
             return;
         const displayIds = [display.id];
         if (root.playlistIsPlayingOnSelectedDisplay(playlist))

--- a/ui/qml/page/WallpaperPage.qml
+++ b/ui/qml/page/WallpaperPage.qml
@@ -776,7 +776,7 @@ MD.Page {
             if (displayIds.length === 0)
                 return;
             if (root.playlistIsSharedActive(playlist))
-                playlistPlaybackMutation.deactivate(displayIds, 0);
+                playlistPlaybackMutation.deactivate(displayIds, playlist.id);
             else
                 playlistPlaybackMutation.activate(playlist.id, displayIds, true);
             return;

--- a/ui/qml/page/WallpaperPage.qml
+++ b/ui/qml/page/WallpaperPage.qml
@@ -705,11 +705,12 @@ MD.Page {
     function displayLabel(display) {
         if (!display)
             return qsTr("Display");
-        const alias = display.displayLabel || "";
-        if (alias.length > 0)
-            return alias;
-        const name = (display.name || "").replace(/^waywallen-[a-z]+-[a-z]+-/, "");
-        return name.length > 0 ? name : qsTr("Display %1").arg(display.id);
+        let base = display.alias || "";
+        if (!base.length)
+            base = (display.name || "").replace(/^waywallen-[a-z]+-[a-z]+-/, "");
+        if (!base.length)
+            return qsTr("Display #%1").arg(display.id);
+        return base + " (#" + display.id + ")";
     }
 
     function selectedPlaylistDisplay() {

--- a/ui/qml/page/wallpaper/PlaylistListSheet.qml
+++ b/ui/qml/page/wallpaper/PlaylistListSheet.qml
@@ -36,12 +36,32 @@ MD.BottomSheet {
                 maximumLineCount: 1
             }
 
+            MD.Text {
+                text: qsTr("Shared")
+                typescale: MD.Token.typescale.body_medium
+                color: MD.Token.color.on_surface_variant
+            }
+
+            MD.Switch {
+                id: sharedSwitch
+                checked: control.sheetState.shareAllDisplays
+                onToggled: control.sheetState.setShareAllDisplays(checked)
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 16
+            Layout.rightMargin: 16
+            Layout.bottomMargin: 8
+            spacing: 8
+
             MD.EmbedChip {
                 id: playlistDisplayChip
 
                 Layout.maximumWidth: 280
                 text: control.sheetState.selectedDisplay ? control.sheetState.displayLabel(control.sheetState.selectedDisplay) : qsTr("No displays")
-                enabled: control.sheetState.playDisplays.length > 0
+                enabled: control.sheetState.playDisplays.length > 0 && !control.sheetState.shareAllDisplays
                 icon.name: MD.Token.icon.monitor
                 trailingIconName: MD.Token.icon.expand_more
                 mdState.borderWidth: 1
@@ -144,7 +164,7 @@ MD.BottomSheet {
                     spacing: 4
 
                     MD.BusyIconButton {
-                        enabled: control.sheetState.selectedDisplay !== null && !control.sheetState.playlistPlaybackMutation.querying
+                        enabled: control.sheetState.hasPlayTarget && !control.sheetState.playlistPlaybackMutation.querying
                         busy: control.sheetState.playlistPlaybackMutation.querying
                         icon.name: playlistSheetItem.playingOnSelectedDisplay ? MD.Token.icon.pause : MD.Token.icon.play_arrow
                         onClicked: control.sheetState.togglePlayback(playlistSheetItem.modelData)

--- a/ui/qml/page/wallpaper/PlaylistListSheetState.qml
+++ b/ui/qml/page/wallpaper/PlaylistListSheetState.qml
@@ -1,4 +1,5 @@
 pragma ComponentBehavior: Bound
+import QtCore
 import QtQml
 
 QtObject {
@@ -8,6 +9,13 @@ QtObject {
     required property var playlistListQuery
     required property var playlistMutation
     required property var playlistPlaybackMutation
+
+    property bool shareAllDisplays: false
+
+    readonly property Settings settings: Settings {
+        category: "PlaylistListSheet"
+        property alias shareAllDisplays: root.shareAllDisplays
+    }
 
     readonly property bool listLoading: page.playlistListLoading
     readonly property var playlists: playlistListQuery.playlists || []
@@ -25,6 +33,7 @@ QtObject {
         return displays[0];
     }
     readonly property var selectedDisplayId: selectedDisplay ? selectedDisplay.id : null
+    readonly property bool hasPlayTarget: shareAllDisplays ? playDisplays.length > 0 : selectedDisplay !== null
 
     function displayLabel(display) {
         return page.displayLabel(display);
@@ -34,12 +43,16 @@ QtObject {
         page.playlistPlayDisplayId = display.id;
     }
 
+    function setShareAllDisplays(shared) {
+        root.shareAllDisplays = !!shared;
+    }
+
     function isEditingPlaylist(playlist) {
         return page.isEditingPlaylist(playlist);
     }
 
     function playlistIsPlayingOnSelectedDisplay(playlist) {
-        return page.playlistIsPlayingOnSelectedDisplay(playlist);
+        return root.shareAllDisplays ? page.playlistIsSharedActive(playlist) : page.playlistIsPlayingOnSelectedDisplay(playlist);
     }
 
     function playlistDisplayLabels(playlist) {
@@ -47,7 +60,7 @@ QtObject {
     }
 
     function togglePlayback(playlist) {
-        page.togglePlaylistPlayback(playlist);
+        page.togglePlaylistPlayback(playlist, root.shareAllDisplays);
     }
 
     function editSelection(playlist) {

--- a/ui/src/objmodel/display.cppm
+++ b/ui/src/objmodel/display.cppm
@@ -61,7 +61,12 @@ public:
     auto id() const -> quint64 { return m_id; }
     auto name() const -> const QString& { return m_name; }
     auto alias() const -> const QString& { return m_alias; }
-    auto displayLabel() const -> QString { return m_alias.isEmpty() ? m_name : m_alias; }
+    auto displayLabel() const -> QString {
+        const QString base = m_alias.isEmpty() ? m_name : m_alias;
+        if (base.isEmpty())
+            return QString("Display #%1").arg(m_id);
+        return QString("%1 (#%2)").arg(base).arg(m_id);
+    }
     auto width() const -> quint32 { return m_width; }
     auto height() const -> quint32 { return m_height; }
     auto refreshMhz() const -> quint32 { return m_refresh_mhz; }


### PR DESCRIPTION
## Summary
- Route multi-display playlist playback through shared sessions so member displays share one rotator and stay in sync.
- Apply shared playlist wallpapers with a single renderer instead of duplicating per display.
- Debounce hotplug restore so reconnecting monitors remount as one shared session; show runtime display ids in UI labels.
- Fix per-display playlist swap reattach races and clear auto-attach so static wallpapers survive restart.
- Add unit tests for shared session