### PR TITLE
build: document Vulkan headers as a separate dependency + clearer find_package error

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,7 +9,8 @@ End-to-end build instructions for developers.
 | Rust | stable | |
 | Clang | 22+ | [LLVM-22.1.4-Linux-X64](https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.4/LLVM-22.1.4-Linux-X64.tar.xz) |
 | CMake | 3.28+ | |
-| Vulkan SDK | ≥ 1.1 |  |
+| Vulkan loader | ≥ 1.1 | runtime: `vulkan-icd-loader` (Arch) · `libvulkan1` (Debian/Ubuntu) · `vulkan-loader` (Fedora) |
+| Vulkan headers | ≥ 1.1 | **build-time**, provides `vulkan/vulkan.h` for `find_package(Vulkan)`: `vulkan-headers` (Arch/Fedora) · `libvulkan-dev` (Debian/Ubuntu). |
 | Qt6 | ≥ 6.10 | Quick, DBus, Protobuf |
 | ffmpeg | - |  |
 

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -45,7 +45,18 @@ find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 pkg_check_modules(WW_BRIDGE_EGL REQUIRED egl)
 pkg_check_modules(WW_BRIDGE_GBM REQUIRED gbm)
-find_package(Vulkan REQUIRED)
+# find_package(Vulkan) needs BOTH the loader and the dev headers
+# (vulkan/vulkan.h); on most distros the headers are a separate package.
+find_package(Vulkan QUIET)
+if(NOT Vulkan_INCLUDE_DIR)
+    message(FATAL_ERROR
+        "Vulkan headers not found (need vulkan/vulkan.h). Install the headers "
+        "package: vulkan-headers (Arch/Fedora) or libvulkan-dev (Debian/Ubuntu).")
+elseif(NOT Vulkan_LIBRARY)
+    message(FATAL_ERROR
+        "Vulkan loader not found (libvulkan). Install the loader: "
+        "vulkan-icd-loader (Arch), libvulkan1 (Debian/Ubuntu), or vulkan-loader (Fedora).")
+endif()
 target_include_directories(waywallen-bridge SYSTEM PRIVATE
     ${WW_BRIDGE_EGL_INCLUDE_DIRS}
     ${WW_BRIDGE_GBM_INCLUDE_DIRS}

--- a/plugins/org.waywallen.image/CMakeLists.txt
+++ b/plugins/org.waywallen.image/CMakeLists.txt
@@ -3,7 +3,18 @@ pkg_check_modules(AVFORMAT REQUIRED IMPORTED_TARGET libavformat>=58)
 pkg_check_modules(AVCODEC  REQUIRED IMPORTED_TARGET libavcodec>=58)
 pkg_check_modules(AVUTIL   REQUIRED IMPORTED_TARGET libavutil>=56)
 pkg_check_modules(SWSCALE  REQUIRED IMPORTED_TARGET libswscale>=5)
-find_package(Vulkan REQUIRED)
+# find_package(Vulkan) needs BOTH the loader and the dev headers
+# (vulkan/vulkan.h); on most distros the headers are a separate package.
+find_package(Vulkan QUIET)
+if(NOT Vulkan_INCLUDE_DIR)
+    message(FATAL_ERROR
+        "Vulkan headers not found (need vulkan/vulkan.h). Install the headers "
+        "package: vulkan-headers (Arch/Fedora) or libvulkan-dev (Debian/Ubuntu).")
+elseif(NOT Vulkan_LIBRARY)
+    message(FATAL_ERROR
+        "Vulkan loader not found (libvulkan). Install the loader: "
+        "vulkan-icd-loader (Arch), libvulkan1 (Debian/Ubuntu), or vulkan-loader (Fedora).")
+endif()
 
 add_executable(waywallen-image-renderer
     src/main.cpp

--- a/plugins/org.waywallen.video/CMakeLists.txt
+++ b/plugins/org.waywallen.video/CMakeLists.txt
@@ -1,4 +1,15 @@
-find_package(Vulkan REQUIRED)
+# find_package(Vulkan) needs BOTH the loader and the dev headers
+# (vulkan/vulkan.h); on most distros the headers are a separate package.
+find_package(Vulkan QUIET)
+if(NOT Vulkan_INCLUDE_DIR)
+    message(FATAL_ERROR
+        "Vulkan headers not found (need vulkan/vulkan.h). Install the headers "
+        "package: vulkan-headers (Arch/Fedora) or libvulkan-dev (Debian/Ubuntu).")
+elseif(NOT Vulkan_LIBRARY)
+    message(FATAL_ERROR
+        "Vulkan loader not found (libvulkan). Install the loader: "
+        "vulkan-icd-loader (Arch), libvulkan1 (Debian/Ubuntu), or vulkan-loader (Fedora).")
+endif()
 
 add_executable(waywallen-video-renderer
     src/main.cpp


### PR DESCRIPTION
`find_package(Vulkan)` needs the dev headers (`vulkan/vulkan.h`), which ship in a different package from the runtime loader. usually with only the loader installed (any GPU driver or game pulls `vulkan-icd-loader`), configure aborts with sort of a cryptic (CMAKE var lang) `missing: Vulkan_INCLUDE_DIR`, and `BUILD.md` only says "Vulkan SDK".

As part of sanity Fix:
- `BUILD.md`: split into explicit loader vs headers rows with per-distro package names (`vulkan-headers` / `libvulkan-dev`).
- bridge + image/video plugins: `find_package(Vulkan QUIET)` + a `FATAL_ERROR` that names the missing piece (headers **or** loader). No change on success.