### PR TITLE
bridge: bound decoder array/list counts by remaining input

### DIFF
--- a/bridge/src/ipc_v3.c
+++ b/bridge/src/ipc_v3.c
@@ -296,6 +296,7 @@ static int rd_string(ww_rd_t *r, char **out) {
     return WW_OK;
 }
 
+/* Guard against an untrusted count forcing a huge allocation (DoS). */
 #define DEFINE_ARRAY_READER(NAME, CTYPE, READ_ONE)                     \
     static int rd_array_##NAME(ww_rd_t *r, ww_array_##NAME##_t *out) { \
         uint32_t n;                                                    \
@@ -304,6 +305,7 @@ static int rd_string(ww_rd_t *r, char **out) {
         out->count = 0;                                                \
         out->data = NULL;                                              \
         if (n == 0) return WW_OK;                                      \
+        if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;      \
         if ((size_t)n > (SIZE_MAX / sizeof(CTYPE))) return WW_ERR_BAD_ARRAY; \
         CTYPE *arr = (CTYPE *)malloc((size_t)n * sizeof(CTYPE));       \
         if (!arr) return WW_ERR_NOMEM;                                 \
@@ -330,6 +332,7 @@ static int rd_array_string(ww_rd_t *r, ww_array_string_t *out) {
     out->count = 0;
     out->data = NULL;
     if (n == 0) return WW_OK;
+    if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;
     if ((size_t)n > (SIZE_MAX / sizeof(char *))) return WW_ERR_BAD_ARRAY;
     char **arr = (char **)calloc(n, sizeof(char *));
     if (!arr) return WW_ERR_NOMEM;
@@ -353,6 +356,7 @@ static int rd_kv_list(ww_rd_t *r, ww_kv_list_t *out) {
     out->count = 0;
     out->data = NULL;
     if (n == 0) return WW_OK;
+    if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;
     if ((size_t)n > (SIZE_MAX / sizeof(ww_kv_t))) return WW_ERR_BAD_ARRAY;
     ww_kv_t *arr = (ww_kv_t *)calloc(n, sizeof(ww_kv_t));
     if (!arr) return WW_ERR_NOMEM;

--- a/bridge/tests/protocol_v3_tests.c
+++ b/bridge/tests/protocol_v3_tests.c
@@ -98,10 +98,28 @@ static void test_audio_helper_validates_complete_windows_and_end(void) {
     ww_bridge_control_free(&control);
 }
 
+/* An untrusted count larger than the remaining input must not force a huge allocation. */
+static void test_decoder_rejects_oversized_array_count(void) {
+    /* setting_changed body is a bare kv_list: [u32 count]. */
+    const uint8_t              kv_huge[4] = { 0xff, 0xff, 0xff, 0xff };
+    ww_evt_in_setting_changed_t settings;
+    assert(ww_evt_in_setting_changed_decode(kv_huge, sizeof(kv_huge), &settings) == WW_ERR_BAD_ARRAY);
+
+    /* set_event_subscriptions body: [u64 revision][u32 kinds count]. */
+    const uint8_t subs_huge[12] = {
+        0, 0, 0, 0, 0, 0, 0, 0,        /* revision = 0 */
+        0xff, 0xff, 0xff, 0xff,        /* kinds.count = UINT32_MAX */
+    };
+    ww_evt_set_event_subscriptions_t subs;
+    assert(ww_evt_set_event_subscriptions_decode(subs_huge, sizeof(subs_huge), &subs)
+           == WW_ERR_BAD_ARRAY);
+}
+
 int main(void) {
     test_subscription_codec();
     test_request_frame_codec();
     test_subscription_ack_view();
     test_audio_helper_validates_complete_windows_and_end();
+    test_decoder_rejects_oversized_array_count();
     return 0;
 }

--- a/tools/wayproto-gen/src/codegen_c.rs
+++ b/tools/wayproto-gen/src/codegen_c.rs
@@ -721,6 +721,7 @@ static int rd_string(ww_rd_t *r, char **out) {
     return WW_OK;
 }
 
+/* Guard against an untrusted count forcing a huge allocation (DoS). */
 #define DEFINE_ARRAY_READER(NAME, CTYPE, READ_ONE)                     \
     static int rd_array_##NAME(ww_rd_t *r, ww_array_##NAME##_t *out) { \
         uint32_t n;                                                    \
@@ -729,6 +730,7 @@ static int rd_string(ww_rd_t *r, char **out) {
         out->count = 0;                                                \
         out->data = NULL;                                              \
         if (n == 0) return WW_OK;                                      \
+        if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;      \
         if ((size_t)n > (SIZE_MAX / sizeof(CTYPE))) return WW_ERR_BAD_ARRAY; \
         CTYPE *arr = (CTYPE *)malloc((size_t)n * sizeof(CTYPE));       \
         if (!arr) return WW_ERR_NOMEM;                                 \
@@ -755,6 +757,7 @@ static int rd_array_string(ww_rd_t *r, ww_array_string_t *out) {
     out->count = 0;
     out->data = NULL;
     if (n == 0) return WW_OK;
+    if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;
     if ((size_t)n > (SIZE_MAX / sizeof(char *))) return WW_ERR_BAD_ARRAY;
     char **arr = (char **)calloc(n, sizeof(char *));
     if (!arr) return WW_ERR_NOMEM;
@@ -778,6 +781,7 @@ static int rd_kv_list(ww_rd_t *r, ww_kv_list_t *out) {
     out->count = 0;
     out->data = NULL;
     if (n == 0) return WW_OK;
+    if ((size_t)n > r->len - r->pos) return WW_ERR_BAD_ARRAY;
     if ((size_t)n > (SIZE_MAX / sizeof(ww_kv_t))) return WW_ERR_BAD_ARRAY;
     ww_kv_t *arr = (ww_kv_t *)calloc(n, sizeof(ww_kv_t));
     if (!arr) return WW_ERR_NOMEM;


### PR DESCRIPTION
In the code, the generated IPC decoders read a `uint32_t` element count and allocate `count * sizeof(elem)` before reading any elements. Seems to be validating only against multiplication overflow... not against how many bytes actually remain. Since a frame body is ≤64 KB but the count is a full `uint32_t`, a small crafted frame can demand a multi-GB allocation.

Fix could be to reject any count larger than the reader's remaining bytes before allocating, in every array/list reader. Each element is ≥1 wire byte, so this never rejects a valid frame while capping allocation to the frame size. 