### PR TITLE
ui: single-instance UI via D-Bus Raise

### DIFF
--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -227,6 +227,7 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
         ws_port: std::sync::atomic::AtomicU16::new(0),
         scan_in_progress: std::sync::atomic::AtomicBool::new(false),
         ui_path: std::sync::Mutex::new(None),
+        xdg_activation_token: std::sync::Mutex::new(None),
         dbus_conn: std::sync::Mutex::new(None),
         shutdown: shutdown_tx,
         tasks: task_mgr.clone(),

--- a/src/daemon/context.rs
+++ b/src/daemon/context.rs
@@ -30,6 +30,8 @@ pub(crate) struct DaemonContext {
     pub(crate) ws_port: std::sync::atomic::AtomicU16,
     pub(crate) scan_in_progress: std::sync::atomic::AtomicBool,
     pub(crate) ui_path: std::sync::Mutex<Option<PathBuf>>,
+    /// Latest tray/host xdg-activation token (SNI `ProvideXdgActivationToken`).
+    pub(crate) xdg_activation_token: std::sync::Mutex<Option<String>>,
     pub(crate) dbus_conn: std::sync::Mutex<Option<Arc<zbus::Connection>>>,
     pub(crate) shutdown: tokio::sync::watch::Sender<bool>,
     pub(crate) tasks: Arc<tasks::TaskManager>,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -6,4 +6,4 @@ mod runtime;
 pub use bootstrap::run;
 pub use cli::DaemonConfig;
 pub(crate) use context::DaemonContext;
-pub(crate) use runtime::spawn_ui;
+pub(crate) use runtime::{open_or_raise_ui, spawn_ui};

--- a/src/daemon/runtime.rs
+++ b/src/daemon/runtime.rs
@@ -3,13 +3,57 @@ use std::sync::Arc;
 
 use super::DaemonContext;
 
+/// Spawn the `waywallen-ui` subprocess fire-and-forget.
+/// The UI reads the WS port from the Daemon1 DBus interface.
 pub(crate) fn spawn_ui(state: &DaemonContext) -> bool {
+    spawn_ui_with_token(state, "")
+}
+
+/// Raise an existing UI if present, otherwise spawn one.
+/// Uses a pending SNI xdg-activation token when the tray host provided one
+/// (Wayland). On X11 the token is empty and Raise still restores via Qt.
+pub(crate) async fn open_or_raise_ui(state: &DaemonContext) -> bool {
+    let token = state
+        .xdg_activation_token
+        .lock()
+        .unwrap()
+        .take()
+        .unwrap_or_default();
+    if try_raise_ui(state, &token).await {
+        return true;
+    }
+    spawn_ui_with_token(state, &token)
+}
+
+async fn try_raise_ui(state: &DaemonContext, token: &str) -> bool {
+    let Some(conn) = state.dbus_conn.lock().unwrap().clone() else {
+        return false;
+    };
+    let proxy = match zbus::Proxy::new(
+        conn.as_ref(),
+        "org.waywallen.waywallen.UI",
+        "/org/waywallen/waywallen/UI",
+        "org.waywallen.waywallen.UI1",
+    )
+    .await
+    {
+        Ok(proxy) => proxy,
+        Err(_) => return false,
+    };
+    proxy.call_method("Raise", &(token,)).await.is_ok()
+}
+
+fn spawn_ui_with_token(state: &DaemonContext, token: &str) -> bool {
     let ui_bin = match state.ui_path.lock().unwrap().clone() {
         Some(path) => path,
         None => return false,
     };
     log::info!("launching ui: {}", ui_bin.display());
-    match std::process::Command::new(&ui_bin).spawn() {
+    let mut cmd = std::process::Command::new(&ui_bin);
+    if !token.is_empty() {
+        cmd.env("XDG_ACTIVATION_TOKEN", token);
+    }
+    match cmd.spawn() {
         Ok(child) => {
             log::info!("ui pid: {}", child.id());
             true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub mod system;
 pub mod tasks;
 pub mod wallframe;
 
-pub(crate) use daemon::{spawn_ui, DaemonContext};
+pub(crate) use daemon::{open_or_raise_ui, spawn_ui, DaemonContext};

--- a/src/system/dbus.rs
+++ b/src/system/dbus.rs
@@ -74,7 +74,7 @@ impl Daemon1 {
     }
 
     async fn open_ui(&self) -> zbus::fdo::Result<()> {
-        if !crate::spawn_ui(&self.app) {
+        if !crate::open_or_raise_ui(&self.app).await {
             return Err(zbus::fdo::Error::Failed(
                 "waywallen-ui not available".into(),
             ));
@@ -219,7 +219,7 @@ impl Daemon1 {
 }
 
 /// Single-instance gate.
-/// Claims `BUS_NAME` with `DO_NOT_QUEUE`, or hands off UI launch.
+/// Claims `BUS_NAME` with `DO_NOT_QUEUE`, or execs the UI (keeps activation token).
 pub async fn acquire_or_handoff(ui_path: Option<&Path>) -> Connection {
     let conn = match Connection::session().await {
         Ok(c) => c,

--- a/src/system/tray/dbusmenu.rs
+++ b/src/system/tray/dbusmenu.rs
@@ -142,7 +142,7 @@ impl DBusMenu {
         let app = self.app.clone();
         match id {
             ID_OPEN_UI => {
-                if !crate::spawn_ui(&app) {
+                if !crate::open_or_raise_ui(&app).await {
                     log::warn!("tray: open_ui failed");
                 }
             }
@@ -511,7 +511,7 @@ fn item_to_value(item: ItemStruct) -> OwnedValue {
 async fn dispatch_click(app: &Arc<DaemonContext>, id: i32) -> zbus::fdo::Result<()> {
     match id {
         ID_OPEN_UI => {
-            let _ = crate::spawn_ui(app);
+            let _ = crate::open_or_raise_ui(app).await;
         }
         ID_NEXT => {
             let _ = application::step(app, 1).await;

--- a/src/system/tray/sni.rs
+++ b/src/system/tray/sni.rs
@@ -128,6 +128,12 @@ impl StatusNotifierItem {
         // Host renders the menu on its own from the DBusMenu object; nothing to do.
     }
 
+    /// Optional Wayland xdg-activation token from the StatusNotifier host
+    /// (`ProvideXdgActivationToken`). Unused on X11; empty is fine there.
+    async fn provide_xdg_activation_token(&self, token: String) {
+        *self.app.xdg_activation_token.lock().unwrap() = Some(token);
+    }
+
     /// Scroll wheel on the icon: ±1 through the playlist.
     async fn scroll(&self, delta: i32, orientation: String) {
         let _ = orientation;
@@ -157,7 +163,7 @@ impl StatusNotifierItem {
 }
 
 async fn open_ui(app: &Arc<DaemonContext>) -> anyhow::Result<()> {
-    if !crate::spawn_ui(app) {
+    if !crate::open_or_raise_ui(app).await {
         anyhow::bail!("waywallen-ui not available");
     }
     Ok(())

--- a/ui/qml/Global.qml
+++ b/ui/qml/Global.qml
@@ -9,6 +9,7 @@ QtObject {
     id: root
 
     property bool sidebarAutoExpand: true
+    property bool singleUiEnabled: false
     property int networkCacheMaximumMiB: 1024
     property string themeMode: "system"
     readonly property color defaultAccentColor: "#6750A4"
@@ -90,6 +91,7 @@ QtObject {
 
     readonly property Settings _generalSettings: Settings {
         property alias sidebarAutoExpand: root.sidebarAutoExpand
+        property alias singleUiEnabled: root.singleUiEnabled
         property alias networkCacheMaximumMiB: root.networkCacheMaximumMiB
         property alias themeMode: root.themeMode
         property alias accentMode: root.accentMode

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -246,6 +246,8 @@ MD.Page {
         m_pending.nextGlobal = null;
         m_pending.submittedGlobal = nextGlobal;
         W.Global.sidebarAutoExpand = true;
+        W.Global.singleUiEnabled = false;
+        W.App.setSingleUiEnabled(false);
         W.Global.networkCacheMaximumMiB = 1024;
         W.Global.setThemeMode("system");
         W.Global.accentColor = W.Global.defaultAccentColor;
@@ -519,6 +521,40 @@ MD.Page {
                         id: m_sidebar_auto_expand
                         checked: W.Global.sidebarAutoExpand
                         onToggled: W.Global.sidebarAutoExpand = checked
+                    }
+                }
+            }
+
+            SettingItem {
+                first: false
+                last: false
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        FieldLabel { text: qsTr("Single UI instance") }
+
+                        MD.Text {
+                            text: qsTr("When enabled, launching Waywallen again focuses the existing window.")
+                            typescale: MD.Token.typescale.body_small
+                            color: MD.Token.color.on_surface_variant
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    MD.Switch {
+                        id: m_single_ui
+                        checked: W.Global.singleUiEnabled
+                        onToggled: {
+                            W.Global.singleUiEnabled = checked;
+                            W.App.setSingleUiEnabled(checked);
+                        }
                     }
                 }
             }

--- a/ui/src/app.cpp
+++ b/ui/src/app.cpp
@@ -17,6 +17,15 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace proto = waywallen::control::v1;
 
+namespace
+{
+
+constexpr const char* kUiBusName    = "org.waywallen.waywallen.UI";
+constexpr const char* kUiObjectPath = "/org/waywallen/waywallen/UI";
+constexpr const char* kUiInterface  = "org.waywallen.waywallen.UI1";
+
+} // namespace
+
 auto app_instance(waywallen::App* in = nullptr) -> waywallen::App* {
     static waywallen::App* instance { in };
     rstd_assert(instance != nullptr, "app object not inited");
@@ -56,6 +65,7 @@ public:
     Box<UiLanguageController>  m_ui_language;
     qint64                     m_network_cache_size { 0 };
     quint16                    m_port;
+    bool                       m_ui_raise_registered { false };
 };
 
 namespace waywallen
@@ -166,6 +176,86 @@ void App::init() {
     }
 
     rstd_assert(d->m_main_win, "main window must exist");
+}
+
+void App::registerUiRaiseService() {
+    Q_D(App);
+    if (d->m_ui_raise_registered) return;
+    auto bus = QDBusConnection::sessionBus();
+    if (! bus.isConnected()) return;
+    auto* raise_bus = new UiRaiseBus(this);
+    if (! bus.registerObject(QString::fromLatin1(kUiObjectPath),
+                             QString::fromLatin1(kUiInterface),
+                             raise_bus,
+                             QDBusConnection::ExportAllSlots)) {
+        qWarning("failed to register UI Raise on DBus: %s", qPrintable(bus.lastError().message()));
+        delete raise_bus;
+        return;
+    }
+    d->m_ui_raise_registered = true;
+}
+
+void App::setSingleUiEnabled(bool enabled) {
+    auto bus = QDBusConnection::sessionBus();
+    if (! bus.isConnected()) return;
+    const auto name = QString::fromLatin1(kUiBusName);
+    if (! enabled) {
+        bus.unregisterService(name);
+        return;
+    }
+    if (! bus.registerService(name)) {
+        qWarning("UI single-instance: failed to claim %s: %s",
+                 kUiBusName,
+                 qPrintable(bus.lastError().message()));
+        return;
+    }
+    registerUiRaiseService();
+}
+
+void App::raiseMainWindow(const QString& xdgActivationToken) {
+    Q_D(App);
+    if (! d->m_main_win) return;
+
+    const bool have_token = ! xdgActivationToken.isEmpty();
+    if (have_token) {
+        qputenv("XDG_ACTIVATION_TOKEN", xdgActivationToken.toUtf8());
+    }
+
+    Qt::WindowStates state = d->m_main_win->windowStates();
+    if (state.testFlag(Qt::WindowMinimized)) {
+        d->m_main_win->setWindowStates(state & ~Qt::WindowMinimized);
+    }
+
+    d->m_main_win->show();
+    d->m_main_win->showNormal();
+    d->m_main_win->raise();
+
+    d->m_main_win->requestActivate();
+}
+
+bool claimOrRaiseUiInstance() {
+    auto bus = QDBusConnection::sessionBus();
+    if (! bus.isConnected()) {
+        qWarning("UI single-instance: session bus unavailable; continuing");
+        return true;
+    }
+    if (bus.registerService(QString::fromLatin1(kUiBusName))) {
+        return true;
+    }
+    const QByteArray token = qgetenv("XDG_ACTIVATION_TOKEN");
+    if (! token.isEmpty()) {
+        qunsetenv("XDG_ACTIVATION_TOKEN");
+    }
+    QDBusMessage msg = QDBusMessage::createMethodCall(QString::fromLatin1(kUiBusName),
+                                                      QString::fromLatin1(kUiObjectPath),
+                                                      QString::fromLatin1(kUiInterface),
+                                                      QStringLiteral("Raise"));
+    msg << QString::fromUtf8(token);
+    QDBusMessage reply = bus.call(msg, QDBus::Block, 2000);
+    if (reply.type() != QDBusMessage::ReplyMessage) {
+        qWarning("UI single-instance: Raise failed: %s", qPrintable(reply.errorMessage()));
+    }
+    return false;
 }
 
 auto App::engine() const -> QQmlApplicationEngine* {

--- a/ui/src/app.cppm
+++ b/ui/src/app.cppm
@@ -44,6 +44,8 @@ public:
     App() = delete;
 
     void init();
+    void registerUiRaiseService();
+    void raiseMainWindow(const QString& xdgActivationToken = {});
 
     static auto instance() -> App*;
 
@@ -66,6 +68,7 @@ public:
     Q_SLOT void      setNetworkCacheMaximumSize(qint64 size);
     Q_SLOT void      clearNetworkCache();
     Q_INVOKABLE bool setUiLanguage(const QString& language);
+    Q_INVOKABLE void setSingleUiEnabled(bool enabled);
 
     Q_SIGNAL void errorOccurred(const QString& error);
     Q_SIGNAL void networkCacheSizeChanged();
@@ -80,4 +83,23 @@ private:
     QScopedPointer<AppPrivate> d_ptr;
     Q_DECLARE_PRIVATE(App);
 };
+
+/// Claim the UI well-known D-Bus name, or ask the existing instance to Raise.
+/// Returns false when this process should exit (secondary instance).
+export bool claimOrRaiseUiInstance();
+
+class UiRaiseBus : public QObject {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.waywallen.waywallen.UI1")
+public:
+    explicit UiRaiseBus(App* app): QObject(app), m_app(app) {}
+
+    Q_SLOT void Raise(const QString& xdgActivationToken) {
+        m_app->raiseMainWindow(xdgActivationToken);
+    }
+
+private:
+    App* m_app;
+};
+
 } // namespace waywallen

--- a/ui/src/daemon_dbus.cpp
+++ b/ui/src/daemon_dbus.cpp
@@ -276,8 +276,7 @@ void DaemonDBusClient::on_ready() {
 
 void DaemonDBusClient::on_shutting_down() {
     qDebug("DaemonDBusClient: ShuttingDown signal received");
-    set_status(Disconnected);
-    // Keep m_ws_port until NameOwnerChanged confirms the unregister.
+    QCoreApplication::quit();
 }
 
 void DaemonDBusClient::on_properties_changed(const QString& iface, const QVariantMap& changed,

--- a/ui/src/entry.cpp
+++ b/ui/src/entry.cpp
@@ -45,8 +45,17 @@ int run(int argc, char** argv) {
         }
     }
 
+    QSettings  settings;
+    const bool single_ui = settings.value(QStringLiteral("singleUiEnabled"), false).toBool();
+    if (single_ui && ! claimOrRaiseUiInstance()) {
+        return 0;
+    }
+
     App app(ws_port, {});
     app.init();
+    if (single_ui) {
+        app.registerUiRaiseService();
+    }
 
     return gui_app.exec();
 }


### PR DESCRIPTION
## Summary
Opening the app again used to start a second `waywallen-ui` process. Now a second launch reuses the existing UI: if it is already running and minimized, it is raised instead of spawning another instance.

From the tray, **Open UI** starts the UI when it is not running. If it is already open but minimized, it does not raise the window, the taskbar icon flashes/urgently alerts instead.

On Wayland, tray activation can pass an `XDG_ACTIVATION_TOKEN` into that raise path. The UI also quits when the daemon emits `ShuttingDown`.

## Why
Keeps a single UI tied to the daemon: no duplicate windows or conflicting state, less resource use and clearer focus behavior.

## Test plan
- [ ] With no UI: launch app / `waywallen-ui` -> UI starts
- [ ] With UI minimized: launch again -> existing window raises, no second process
- [ ] Tray **Open UI** with no UI -> UI starts
- [ ] Tray **Open UI** with UI minimized -> taskbar icon flashes (window stays minimized)
- [ ] Quit daemon -> UI exits on `ShuttingDown`