### PR TITLE
i18n: refresh the catalogs, finish the Russian one

### DIFF
--- a/ui/i18n/waywallen_ru.ts
+++ b/ui/i18n/waywallen_ru.ts
@@ -136,10 +136,6 @@
         <translation>Выход</translation>
     </message>
     <message>
-        <source>Assigned</source>
-        <translation>Назначено</translation>
-    </message>
-    <message>
         <source>Restart</source>
         <translation>Перезапустить</translation>
     </message>
@@ -269,8 +265,8 @@
         <translation>Мониторы не зарегистрированы</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>Монитор %1</translation>
+        <source>Display #%1</source>
+        <translation>Монитор #%1</translation>
     </message>
     <message>
         <source>Edit display</source>
@@ -291,6 +287,10 @@
     <message>
         <source>Connected</source>
         <translation>Подключено</translation>
+    </message>
+    <message>
+        <source>Assigned</source>
+        <translation>Назначено</translation>
     </message>
     <message numerus="yes">
         <source>%n min left</source>
@@ -459,6 +459,17 @@
     </message>
 </context>
 <context>
+    <name>PagePopup</name>
+    <message>
+        <source>Failed to open page</source>
+        <translation>Не удалось открыть страницу</translation>
+    </message>
+    <message>
+        <source>Failed to load page</source>
+        <translation>Не удалось загрузить страницу</translation>
+    </message>
+</context>
+<context>
     <name>PlaylistDetailPanel</name>
     <message>
         <source>Name</source>
@@ -494,6 +505,10 @@
     <message>
         <source>Playlists</source>
         <translation>Плейлисты</translation>
+    </message>
+    <message>
+        <source>Shared</source>
+        <translation>Общий</translation>
     </message>
     <message>
         <source>No displays</source>
@@ -1158,6 +1173,14 @@ Related display: #%1</source>
         <translation>Запускать при входе в систему</translation>
     </message>
     <message>
+        <source>Hide tray icon</source>
+        <translation>Скрыть значок в системном лотке</translation>
+    </message>
+    <message>
+        <source>Remove the status-bar icon. Reopen this window by launching Waywallen again.</source>
+        <translation>Убрать значок из системного лотка. Чтобы снова открыть это окно, запустите Waywallen ещё раз.</translation>
+    </message>
+    <message>
         <source>Allow duplicate renderers</source>
         <translation>Разрешить дублирование рендереров</translation>
     </message>
@@ -1346,10 +1369,6 @@ Unsaved frame state may be lost.</source>
     <message>
         <source>No renderers</source>
         <translation>Рендереров нет</translation>
-    </message>
-    <message>
-        <source>Exit</source>
-        <translation>Выход</translation>
     </message>
     <message>
         <source>Components</source>
@@ -1610,10 +1629,6 @@ Unsaved frame state may be lost.</source>
         <translation>Ко всем</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>Монитор %1</translation>
-    </message>
-    <message>
         <source>Renderer</source>
         <translation>Рендерер</translation>
     </message>
@@ -1858,8 +1873,8 @@ Unsaved frame state may be lost.</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>Монитор %1</translation>
+        <source>Display #%1</source>
+        <translation>Монитор #%1</translation>
     </message>
     <message>
         <source>Added to playlist</source>

--- a/ui/i18n/waywallen_zh_CN.ts
+++ b/ui/i18n/waywallen_zh_CN.ts
@@ -134,10 +134,6 @@
         <translation>退出</translation>
     </message>
     <message>
-        <source>Assigned</source>
-        <translation>已分配</translation>
-    </message>
-    <message>
         <source>Restart</source>
         <translation>重启</translation>
     </message>
@@ -267,8 +263,8 @@
         <translation>没有已注册的显示器</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>显示器 %1</translation>
+        <source>Display #%1</source>
+        <translation>显示器 #%1</translation>
     </message>
     <message>
         <source>Edit display</source>
@@ -289,6 +285,10 @@
     <message>
         <source>Connected</source>
         <translation>已连接</translation>
+    </message>
+    <message>
+        <source>Assigned</source>
+        <translation>已分配</translation>
     </message>
     <message numerus="yes">
         <source>%n min left</source>
@@ -455,6 +455,17 @@
     </message>
 </context>
 <context>
+    <name>PagePopup</name>
+    <message>
+        <source>Failed to open page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load page</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlaylistDetailPanel</name>
     <message>
         <source>Name</source>
@@ -490,6 +501,10 @@
     <message>
         <source>Playlists</source>
         <translation>播放列表</translation>
+    </message>
+    <message>
+        <source>Shared</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No displays</source>
@@ -1152,6 +1167,14 @@ Related display: #%1</source>
         <translation>登录时启动</translation>
     </message>
     <message>
+        <source>Hide tray icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove the status-bar icon. Reopen this window by launching Waywallen again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Allow duplicate renderers</source>
         <translation>允许重复渲染器</translation>
     </message>
@@ -1340,10 +1363,6 @@ Unsaved frame state may be lost.</source>
     <message>
         <source>No renderers</source>
         <translation>没有渲染器</translation>
-    </message>
-    <message>
-        <source>Exit</source>
-        <translation>退出</translation>
     </message>
     <message>
         <source>Components</source>
@@ -1604,10 +1623,6 @@ Unsaved frame state may be lost.</source>
         <translation>全部</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>显示器 %1</translation>
-    </message>
-    <message>
         <source>Renderer</source>
         <translation>渲染器</translation>
     </message>
@@ -1850,8 +1865,8 @@ Unsaved frame state may be lost.</source>
         <translation>显示器</translation>
     </message>
     <message>
-        <source>Display %1</source>
-        <translation>显示器 %1</translation>
+        <source>Display #%1</source>
+        <translation>显示器 #%1</translation>
     </message>
     <message>
         <source>Added to playlist</source>


### PR DESCRIPTION
The catalogs had drifted. `cmake --build <builddir> --target update_translations` finds
8 new sources and drops 5 obsolete entries.

New strings: "Hide tray icon" and its description, "Shared", "Failed to open page",
"Failed to load page".

I filled in the Russian side — `waywallen_ru.ts` is complete again, 456/456. The Chinese
file keeps the five new strings unfinished for a Chinese speaker; I only confirmed the
two that the same-text heuristic pulled from entries already in that file.

Might be worth running the target before a release so the catalogs don't drift again.
