### PR TITLE
ui: fall back to the qtbase catalog for Qt's own strings

### DIFF
--- a/ui/src/ui_language.cpp
+++ b/ui/src/ui_language.cpp
@@ -154,12 +154,21 @@ auto UiLanguageController::applyLanguage(const QString& preference, bool persist
     const auto locale = preference == QString::fromLatin1(kSystemLanguage) ? QLocale::system()
                                                                            : QLocale(preference);
 
-    auto       next_qt_translator = Box<QTranslator>::make();
-    const bool next_qt_loaded =
-        next_qt_translator->load(locale,
-                                 QStringLiteral("qt"),
-                                 QStringLiteral("_"),
-                                 QLibraryInfo::path(QLibraryInfo::TranslationsPath));
+    // "qt" is the umbrella catalog and ships only with a full Qt installation.
+    // Deployments that carry qtbase alone - the AppImage, the Flatpak runtime,
+    // distros that split Qt translations per module - have "qtbase" only, so
+    // fall back to it before giving up on Qt's own strings.
+    const auto qt_translations = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+
+    auto next_qt_translator = Box<QTranslator>::make();
+    auto next_qt_catalog    = QStringLiteral("qt");
+    bool next_qt_loaded =
+        next_qt_translator->load(locale, next_qt_catalog, QStringLiteral("_"), qt_translations);
+    if (! next_qt_loaded) {
+        next_qt_catalog = QStringLiteral("qtbase");
+        next_qt_loaded =
+            next_qt_translator->load(locale, next_qt_catalog, QStringLiteral("_"), qt_translations);
+    }
 
     auto       next_app_translator = Box<QTranslator>::make();
     const bool next_app_loaded     = next_app_translator->load(
@@ -210,7 +219,7 @@ auto UiLanguageController::applyLanguage(const QString& preference, bool persist
           qPrintable(m_preference),
           qPrintable(m_resolved_language),
           next_app_loaded ? "loaded" : "source",
-          next_qt_loaded ? "loaded" : "source");
+          next_qt_loaded ? qPrintable(next_qt_catalog) : "source");
     return true;
 }
 


### PR DESCRIPTION
On a Russian locale the app strings are translated but Qt's own ones are not. The startup
line says it:

```
ui language: preference=system resolved=ru_RU app_catalog=loaded qt_catalog=source
```

`applyLanguage()` asks for the `qt` catalog only. In Qt 6 that is a stub naming other
catalogs — `qt_ru.qm` here is 102 bytes and lists `qtbase_ru`, `qtmultimedia_ru` — and it
ships only with a full Qt install. The AppImage carries 74 `.qm` files, every one of them
`qtbase_*`, so the load always fails. The Flatpak runtime and the distros that split Qt
translations per module are in the same spot.

What it costs is every dialog with `standardButtons`. Without a Qt catalog: Cancel, Reset,
Apply, Close. With `qtbase_ru`: Отмена, Сбросить, Применить, Закрыть.

The patch tries `qt` first, then `qtbase`, and the log now names the catalog it loaded.

Tested by pointing the Qt translations path at a directory holding only `qtbase_*.qm`:
before the patch `qt_catalog=source`, after it `qt_catalog=qtbase`; on a full Qt install
it still says `qt`.
