### PR TITLE
Pass a renderer's single linked display's real size in Init

### DIFF
--- a/bridge/include/waywallen-bridge/bridge.h
+++ b/bridge/include/waywallen-bridge/bridge.h
@@ -356,7 +356,7 @@ void ww_bridge_control_free(ww_bridge_control_t* msg);
  * validates the value sent by the daemon matches and returns -EPROTO
  * otherwise. */
 #define WW_BRIDGE_SUPPORTED_PROTOCOL_VERSION 3u
-#define WW_BRIDGE_SUPPORTED_SPAWN_VERSION    10u
+#define WW_BRIDGE_SUPPORTED_SPAWN_VERSION    11u
 
 /* Receive the daemon's typed `init` request and copy it into `out`.
  *

--- a/bridge/include/waywallen-bridge/ipc_v3.h
+++ b/bridge/include/waywallen-bridge/ipc_v3.h
@@ -288,6 +288,8 @@ typedef struct waywallen_renderer_init {
     uint32_t spawn_version;
     ww_kv_list_t settings;
     char * user_properties;
+    uint32_t display_width;
+    uint32_t display_height;
 } waywallen_renderer_init_t;
 
 typedef struct waywallen_rgba_color {

--- a/bridge/src/ipc_v3.c
+++ b/bridge/src/ipc_v3.c
@@ -1077,6 +1077,8 @@ static int w_renderer_init(ww_buf_t *b, const waywallen_renderer_init_t *v) {
     if ((rc = w_u32(b, v->spawn_version))) return rc;
     if ((rc = w_kv_list(b, &v->settings))) return rc;
     if ((rc = w_string(b, v->user_properties))) return rc;
+    if ((rc = w_u32(b, v->display_width))) return rc;
+    if ((rc = w_u32(b, v->display_height))) return rc;
     return WW_OK;
 }
 
@@ -1086,6 +1088,8 @@ static int rd_renderer_init(ww_rd_t *r, waywallen_renderer_init_t *v) {
     if ((rc = rd_u32(r, &v->spawn_version))) return rc;
     if ((rc = rd_kv_list(r, &v->settings))) return rc;
     if ((rc = rd_string(r, &v->user_properties))) return rc;
+    if ((rc = rd_u32(r, &v->display_width))) return rc;
+    if ((rc = rd_u32(r, &v->display_height))) return rc;
     return WW_OK;
 }
 

--- a/plugins/org.waywallen.image/plugin.toml
+++ b/plugins/org.waywallen.image/plugin.toml
@@ -12,7 +12,7 @@ bin = "../../../../bin/waywallen-image-renderer"
 types = ["image"]
 priority = 100
 activity = "on_demand"
-spawn_version = 10
+spawn_version = 11
 
 [renderers.waywallen-image.settings]
 fps = { type = "u32", default = 30, min = 1, max = 240, step = 1, identity = true, label_key = "settings.image.fps", group = "render", order = 10 }

--- a/plugins/org.waywallen.video/plugin.toml
+++ b/plugins/org.waywallen.video/plugin.toml
@@ -17,7 +17,7 @@ bin = "../../../../bin/waywallen-video-renderer"
 types = ["video"]
 priority = 100
 activity = "continuous"
-spawn_version = 10
+spawn_version = 11
 
 [renderers.waywallen-video.settings]
 loop_file = { type = "string", default = "inf", choices = ["inf", "no"], identity = false, label_key = "settings.video.loop_file", group = "playback", order = 10 }

--- a/protocol/waywallen_ipc_v3.xml
+++ b/protocol/waywallen_ipc_v3.xml
@@ -83,6 +83,9 @@
     <field name="settings" type="kv_list"/>
     <!-- Raw user_property_overrides JSON; empty when unavailable. -->
     <field name="user_properties" type="string"/>
+    <!-- Real size (px) of the renderer's single linked display; both zero if unknown. -->
+    <field name="display_width" type="u32"/>
+    <field name="display_height" type="u32"/>
   </struct>
 
   <struct name="control_transition">

--- a/src/api/websocket/handlers.rs
+++ b/src/api/websocket/handlers.rs
@@ -57,6 +57,7 @@ pub(super) async fn dispatch_inner(
                 renderer_name: Some(renderer_name),
                 user_property_overrides: Default::default(),
                 default_user_properties: Default::default(),
+                display_size: None,
             };
             // Wallframe returns typed spawn errors directly.
             let id = state.router.spawn_renderer(spawn_req).await?;

--- a/src/application/playback/apply.rs
+++ b/src/application/playback/apply.rs
@@ -283,6 +283,7 @@ pub async fn apply_wallpaper(
     let spawn_settings = app.settings.resolved_renderer_settings(&renderer);
     let (user_property_overrides, wallpaper_layout_override) =
         repo::get_wallpaper_render_properties(&app.db, entry.item_id).await?;
+    // `apply_assignment` resolves display_size per renderer.
     let spawn_req = renderer_manager::SpawnRequest {
         wp_type: entry.wp_type.clone(),
         extras: apply.extras,
@@ -291,6 +292,7 @@ pub async fn apply_wallpaper(
         renderer_name: Some(renderer_plugin_name.clone()),
         user_property_overrides,
         default_user_properties: apply.default_user_properties,
+        display_size: None,
     };
     let target = request.display_ids.as_deref();
     let target_ids = app.router.registered_display_ids(target).await;

--- a/src/wallframe/ipc/uds.rs
+++ b/src/wallframe/ipc/uds.rs
@@ -308,6 +308,8 @@ mod tests {
                 spawn_version: 10,
                 settings: vec![("fps".into(), "60".into()), ("volume".into(), "1.0".into())],
                 user_properties: String::new(),
+                display_width: 0,
+                display_height: 0,
             },
         };
         let _ = PROTOCOL_VERSION; // silence unused-import warning

--- a/src/wallframe/renderer_manager/handshake.rs
+++ b/src/wallframe/renderer_manager/handshake.rs
@@ -10,6 +10,8 @@ pub(crate) fn build_init_msg(req: &SpawnRequest, def: &RendererDef) -> ControlMs
     let mut settings: Vec<(String, String)> = settings_kv.into_iter().collect();
     settings.sort_by(|a, b| a.0.cmp(&b.0));
 
+    // Wire has no optional-scalar encoding; None -> 0,0.
+    let (display_width, display_height) = req.display_size.unwrap_or((0, 0));
     ControlMsg::Init {
         config: RendererInit {
             protocol_version: crate::wallframe::ipc::proto::PROTOCOL_VERSION,
@@ -19,6 +21,8 @@ pub(crate) fn build_init_msg(req: &SpawnRequest, def: &RendererDef) -> ControlMs
                 &req.default_user_properties,
                 &req.user_property_overrides,
             ),
+            display_width,
+            display_height,
         },
     }
 }

--- a/src/wallframe/renderer_manager/mod.rs
+++ b/src/wallframe/renderer_manager/mod.rs
@@ -24,7 +24,7 @@ use crate::wallframe::ipc::uds::{recv_event, send_control};
 
 /// Renderer IPC compatibility version the daemon currently emits. Bump
 /// this when the daemon/renderer wire contract changes.
-pub const SPAWN_VERSION: u32 = 10;
+pub const SPAWN_VERSION: u32 = 11;
 use crate::catalog::entry::WallpaperType;
 use crate::plugin::renderer_registry::{RendererActivityMode, RendererDef, RendererRegistry};
 use crate::settings::SettingsStore;
@@ -186,6 +186,8 @@ pub struct SpawnRequest {
     /// Source-authored defaults for renderer-owned user properties.
     /// Persisted overrides take precedence when the Init payload is built.
     pub default_user_properties: HashMap<String, String>,
+    /// Real (width, height) of this spawn's single target display, if known.
+    pub display_size: Option<(u32, u32)>,
 }
 
 /// Immutable renderer publication created from one `BindBuffers` event.
@@ -2269,6 +2271,7 @@ mod init_handshake_tests {
             renderer_name: None,
             user_property_overrides: HashMap::new(),
             default_user_properties: HashMap::new(),
+            display_size: None,
         };
         let msg = build_init_msg(&req, &def_mpv_schema());
         match msg {
@@ -2283,6 +2286,50 @@ mod init_handshake_tests {
                     vec![("loop_file".to_string(), "inf".to_string())]
                 );
                 assert_eq!(config.user_properties, "");
+            }
+            other => panic!("expected ControlMsg::Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_carries_display_size_when_set() {
+        let req = SpawnRequest {
+            extras: HashMap::new(),
+            wp_type: "web".into(),
+            settings: HashMap::new(),
+            test_pattern: false,
+            renderer_name: None,
+            user_property_overrides: HashMap::new(),
+            default_user_properties: HashMap::new(),
+            display_size: Some((3440, 1440)),
+        };
+        let msg = build_init_msg(&req, &def_mpv_schema());
+        match msg {
+            ControlMsg::Init { config } => {
+                assert_eq!(config.display_width, 3440);
+                assert_eq!(config.display_height, 1440);
+            }
+            other => panic!("expected ControlMsg::Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_defaults_display_size_to_zero() {
+        let req = SpawnRequest {
+            extras: HashMap::new(),
+            wp_type: "web".into(),
+            settings: HashMap::new(),
+            test_pattern: false,
+            renderer_name: None,
+            user_property_overrides: HashMap::new(),
+            default_user_properties: HashMap::new(),
+            ..Default::default()
+        };
+        let msg = build_init_msg(&req, &def_mpv_schema());
+        match msg {
+            ControlMsg::Init { config } => {
+                assert_eq!(config.display_width, 0);
+                assert_eq!(config.display_height, 0);
             }
             other => panic!("expected ControlMsg::Init, got {other:?}"),
         }
@@ -2430,6 +2477,7 @@ mod init_handshake_tests {
             renderer_name: None,
             user_property_overrides: HashMap::new(),
             default_user_properties: HashMap::new(),
+            display_size: None,
         };
         let init = build_init_msg(&req, &def_legacy("wescene-renderer"));
         let err =

--- a/src/wallframe/routing/router/composition.rs
+++ b/src/wallframe/routing/router/composition.rs
@@ -152,13 +152,18 @@ impl Router {
                 let renderer_id = reusable_running
                     .or(reusable_terminal)
                     .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                // Singleton groups get their own display's real size.
+                let mut group_spawn_request = request.spawn_request.clone();
+                if let [only_id] = group[..] {
+                    if let Some(display) = inner.displays.get(&only_id) {
+                        group_spawn_request.display_size =
+                            Some((display.info.metrics.width, display.info.metrics.height));
+                    }
+                }
                 if !inner.renderer_slots.contains_key(&renderer_id) {
                     inner.renderer_slots.insert(
                         renderer_id.clone(),
-                        RendererSlot::retained(
-                            request.spawn_request.clone(),
-                            renderer_name.clone(),
-                        ),
+                        RendererSlot::retained(group_spawn_request.clone(), renderer_name.clone()),
                     );
                 } else if !inner
                     .renderer_slots
@@ -170,7 +175,7 @@ impl Router {
                         .get_mut(&renderer_id)
                         .expect("selected renderer slot disappeared")
                         .replace_spec(
-                            request.spawn_request.clone(),
+                            group_spawn_request.clone(),
                             renderer_name.clone(),
                             request.preempt_pending_start,
                         );

--- a/src/wallframe/routing/router/mod.rs
+++ b/src/wallframe/routing/router/mod.rs
@@ -3060,6 +3060,56 @@ mod tests {
         display.id
     }
 
+    #[tokio::test]
+    async fn duplicate_renderers_each_get_their_own_display_size() {
+        let router = Router::new(Arc::new(RendererManager::new_default()));
+        let a = router.register_display(reg("DP-1", 1920, 1080)).await;
+        let b = router.register_display(reg("DP-2", 3440, 1440)).await;
+
+        // Start attempt fails (no registered renderer def); irrelevant here.
+        let _ = router
+            .apply_assignment(ApplyAssignment {
+                spawn_request: crate::wallframe::renderer_manager::SpawnRequest {
+                    wp_type: "web".into(),
+                    renderer_name: Some("web".into()),
+                    ..Default::default()
+                },
+                display_ids: vec![a.id, b.id],
+                duplicate_renderers: true,
+                wallpaper_layout_override: WallpaperLayoutOverride::default(),
+                preempt_pending_start: false,
+            })
+            .await;
+
+        let inner = router.inner.lock().await;
+        let renderer_for = |display_id: DisplayId| {
+            inner
+                .table
+                .links_for_display(display_id)
+                .first()
+                .expect("display linked")
+                .renderer_id
+                .clone()
+        };
+        let size_for = |renderer_id: &str| {
+            inner
+                .renderer_slots
+                .get(renderer_id)
+                .expect("renderer slot")
+                .spawn_request
+                .display_size
+        };
+
+        let renderer_a = renderer_for(a.id);
+        let renderer_b = renderer_for(b.id);
+        assert_ne!(
+            renderer_a, renderer_b,
+            "duplicate_renderers must not share one renderer"
+        );
+        assert_eq!(size_for(&renderer_a), Some((1920, 1080)));
+        assert_eq!(size_for(&renderer_b), Some((3440, 1440)));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn auto_replay_start_waits_for_a_stable_window() {
         let mgr = Arc::new(RendererManager::new_default());

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -497,6 +497,7 @@ mod sync_fd_fanout {
                 renderer_name: None,
                 user_property_overrides: std::collections::HashMap::new(),
                 default_user_properties: std::collections::HashMap::new(),
+                display_size: None,
             })
             .await;
         let renderer_id = match spawn_res {
@@ -600,6 +601,7 @@ mod sync_fd_single {
                 renderer_name: None,
                 user_property_overrides: std::collections::HashMap::new(),
                 default_user_properties: std::collections::HashMap::new(),
+                display_size: None,
             })
             .await;
         let renderer_id = match spawn_res {

--- a/tests/ipc_renderer.rs
+++ b/tests/ipc_renderer.rs
@@ -369,6 +369,7 @@ mod lifecycle {
             renderer_name: None,
             user_property_overrides: std::collections::HashMap::new(),
             default_user_properties: std::collections::HashMap::new(),
+            display_size: None,
         };
         let id = mgr.spawn(req).await.expect("spawn");
         assert!(!id.is_empty());

--- a/tests/release_syncobj_e2e.rs
+++ b/tests/release_syncobj_e2e.rs
@@ -88,6 +88,8 @@ fn release_syncobj_round_trip() {
                 spawn_version: waywallen::wallframe::renderer_manager::SPAWN_VERSION,
                 settings: Vec::new(),
                 user_properties: String::new(),
+                display_width: 0,
+                display_height: 0,
             },
         },
         &[],


### PR DESCRIPTION
## Problem

CEF-hosted web wallpapers (via `open-wallpaper-engine`) have no authored native aspect ratio the way `.pkg` scenes do (their `canvas_extent`), so `weweb-renderer`'s `web_entry.cpp` hardcodes a 16:9 baseline canvas for every resolution preset, regardless of the real monitor. On any non-16:9 display this forces the compositor to stretch that baseline to fit, and pushes wallpapers to invent client-side workarounds to discover their real screen size instead.

## What this does

Threads a display's real physical size into the renderer `Init` handshake, for every case where a spawn maps unambiguously to exactly one display — including each renderer spawned individually under the `duplicate_renderers_for_same_wallpaper` setting, not just the simple single-display-overall case.

- New `renderer_init.display_width`/`display_height` (`u32`, `0`/`0` = unknown), matching the existing 0-means-unknown convention already used by `refresh_mhz` in `waywallen_display_v1`.
- Resolved per renderer-group inside `Router::apply_assignment`, so both of these end up correct:
  - a spawn that targets exactly one display overall, and
  - each independently-spawned renderer under `duplicate_renderers_for_same_wallpaper`, which is 1:1 with its own display internally but previously had no way to learn that display's size.
- Correctly stays unknown when one renderer mirrors to multiple differently-sized displays via frame fan-out (the default multi-monitor behavior when applying the same wallpaper to several screens) — there's no single "native" size in that case. Mismatched mirrored monitors are already handled correctly today, independently per display, downstream in the compositor's fillmode step (`display/layout.rs`); this change doesn't touch that path.
- Renderers that don't read the new fields are unaffected.

## Why `SPAWN_VERSION` bumps

The wire struct's layout is positional, not self-describing (see the protocol XML's own doc comments), so any field addition needs a version bump. This isn't really avoidable by trying to make the fields optional-on-the-wire instead: the generated C decoder (`bridge/src/ipc_v3.c`) already strictly rejects unrecognized trailing bytes (`WW_ERR_TRAILING`), so appending fields breaks old renderer builds either way. The version bump just converts that into an explicit, actionable rejection (`validate_renderer_spawn_version`, with a message telling the plugin author what to do) instead of a cryptic wire-decode failure.

- Bundled `image`/`video` plugins' declared `spawn_version` bumped to `11` to match.
- `bridge/`'s generated C bindings regenerated (`bridge/scripts/regen.sh`) and its hand-maintained `WW_BRIDGE_SUPPORTED_SPAWN_VERSION` constant bumped. Without this, the bundled renderer binaries — which link against `bridge/` — would silently fail the new `Init` handshake and stop spawning. (This constant isn't touched by codegen; confirmed by checking `wayproto-gen`'s source and the CMake build for any auto-sync path — there is none.)
- Third-party renderer plugins, including `open-wallpaper-engine`, will need the same bump to keep spawning, and can start reading the new fields whenever they're ready to. That's tracked as follow-up work in that repo, not part of this PR.

## Testing

- `cargo build --package waywallen --tests`: clean.
- Full suite: 460 tests, 0 failures (`cargo test --package waywallen`).
- New/changed tests: `init_carries_display_size_when_set`, `init_defaults_display_size_to_zero`, and `duplicate_renderers_each_get_their_own_display_size` (two displays of different real sizes, `duplicate_renderers: true` — verifies each ends up on its own renderer with its own correct size, not sharing one value).
- Live-verified against a real desktop session: stopped a running production daemon, launched this branch's build in its place (same D-Bus service name, same on-disk plugin install), and confirmed from logs that a real single-display recall correctly resolved the true monitor size (`3440x1440`, a real ultrawide) and that an unmodified `weweb-renderer` binary correctly rejected the larger `Init` message it doesn't understand yet, rather than misbehaving silently — confirming both the daemon-side plumbing and the version gate work as intended before any client-side changes exist. Production was restored afterward with no lasting effect.

## Out of scope / follow-up

- `open-wallpaper-engine`'s `weweb-renderer` still needs to read the new fields and declare `spawn_version = 11` — separate repo, not started here.
- `bridge/`'s regenerated C source hasn't been compiled — no C/C++ toolchain was available in this environment. Worth a real build pass before merge.
