### PR TITLE
ui: limit the height of combobox and add vertical scroll

### DIFF
--- a/ui/qml/page/WallpaperDetailPanel.qml
+++ b/ui/qml/page/WallpaperDetailPanel.qml
@@ -939,6 +939,7 @@ Item {
                     visible: m_prop_delegate.type === "combo" && m_prop_delegate.supported
                     Layout.fillWidth: true
                     mdState.size: MD.Enum.S
+                    popupMaximumHeight: Math.min(320, (Window.window?.height ?? 480) * 0.45)
                     model: m_prop_delegate.optionLabels || []
                     onActivated: idx => {
                         const values = m_prop_delegate.optionValues || [];


### PR DESCRIPTION
## Summary
- Cap the wallpaper property ComboBox popup at `min(320px, 45% of window height)` so long option lists no longer overflow or clip the window.
- This lets the popup scroll vertically when a property has many values.
- Addresses feedback from Do'tasarr on Discord.