### PR TITLE
ui: stop printing unresolved i18n keys as setting labels

### DIFF
--- a/ui/qml/component/settings/SettingField.qml
+++ b/ui/qml/component/settings/SettingField.qml
@@ -7,6 +7,15 @@ import waywallen.ui as W
 
 // Renders one schema-driven control. The schema dict comes from
 // `RendererPluginListQuery.renderers[i].settings[j]`.
+//
+// `schema.label` does not always carry human text. When a manifest
+// declares no translated `label`, `pluginMessageFromPb` substitutes the
+// raw `label_key` (`renderer_query.cpp`), and `W.I18n.tr` returns a
+// plain string unchanged -- so a manifest still on the deprecated
+// `label_key` form puts `settings.video.hwdec` where the name belongs.
+// A dotted, space-free value is therefore treated as an unresolved key
+// and falls through to the `key` transform. Real translations and the
+// human labels source plugins supply contain spaces and pass through.
 ColumnLayout {
     id: root
 
@@ -27,12 +36,17 @@ ColumnLayout {
     readonly property int kBool: 4
     readonly property int kI32: 5
 
+    // A dotted, space-free token is an unresolved i18n key, not a label.
+    function isUnresolvedKey(s) {
+        return s.indexOf(".") >= 0 && !/\s/.test(s);
+    }
+
     readonly property string label: {
         const translated = W.I18n.tr(schema.label);
-        if (translated.length > 0)
+        if (translated.length > 0 && !root.isUnresolvedKey(translated))
             return translated;
         const sk = schema.label_key || "";
-        if (sk.length > 0)
+        if (sk.length > 0 && !root.isUnresolvedKey(sk))
             return sk;
         const raw = schema.key || "";
         if (raw.length === 0)
@@ -44,7 +58,10 @@ ColumnLayout {
 
     readonly property string description: {
         const translated = W.I18n.tr(schema.description);
-        return translated.length > 0 ? translated : (schema.description_key || "");
+        if (translated.length > 0 && !root.isUnresolvedKey(translated))
+            return translated;
+        const dk = schema.description_key || "";
+        return root.isUnresolvedKey(dk) ? "" : dk;
     }
     // Bare http(s) URLs in the description become clickable links
     readonly property string descriptionHtml: {

--- a/ui/qml/component/settings/SettingField.qml
+++ b/ui/qml/component/settings/SettingField.qml
@@ -9,13 +9,14 @@ import waywallen.ui as W
 // `RendererPluginListQuery.renderers[i].settings[j]`.
 //
 // `schema.label` does not always carry human text. When a manifest
-// declares no translated `label`, `pluginMessageFromPb` substitutes the
-// raw `label_key` (`renderer_query.cpp`), and `W.I18n.tr` returns a
-// plain string unchanged -- so a manifest still on the deprecated
-// `label_key` form puts `settings.video.hwdec` where the name belongs.
-// A dotted, space-free value is therefore treated as an unresolved key
-// and falls through to the `key` transform. Real translations and the
-// human labels source plugins supply contain spaces and pass through.
+// declares a translated `label` it arrives as a PluginMessage object;
+// when it does not, `pluginMessageFromPb` substitutes the raw
+// `label_key` string (`renderer_query.cpp`) and `W.I18n.tr` returns it
+// unchanged -- so a manifest still on the deprecated `label_key` form
+// puts `settings.video.hwdec` where the name belongs. Only that second,
+// string form is examined: a dotted, space-free value there is treated
+// as an unresolved key and falls through to the `key` transform. A
+// resolved PluginMessage is printed as it comes, whatever it contains.
 ColumnLayout {
     id: root
 
@@ -36,17 +37,24 @@ ColumnLayout {
     readonly property int kBool: 4
     readonly property int kI32: 5
 
+    // A PluginMessage carries a msgid the catalog resolved; a bare string
+    // is the raw manifest value `pluginMessageFromPb` fell back to.
+    function isPluginMessage(v) {
+        return v !== null && typeof v === "object" && !!v.msgid;
+    }
+
     // A dotted, space-free token is an unresolved i18n key, not a label.
-    function isUnresolvedKey(s) {
-        return s.indexOf(".") >= 0 && !/\s/.test(s);
+    // Never applied to text that came from a PluginMessage.
+    function isUnresolvedKey(source, s) {
+        return !root.isPluginMessage(source) && s.indexOf(".") >= 0 && !/\s/.test(s);
     }
 
     readonly property string label: {
         const translated = W.I18n.tr(schema.label);
-        if (translated.length > 0 && !root.isUnresolvedKey(translated))
+        if (translated.length > 0 && !root.isUnresolvedKey(schema.label, translated))
             return translated;
         const sk = schema.label_key || "";
-        if (sk.length > 0 && !root.isUnresolvedKey(sk))
+        if (sk.length > 0 && !root.isUnresolvedKey(sk, sk))
             return sk;
         const raw = schema.key || "";
         if (raw.length === 0)
@@ -58,10 +66,10 @@ ColumnLayout {
 
     readonly property string description: {
         const translated = W.I18n.tr(schema.description);
-        if (translated.length > 0 && !root.isUnresolvedKey(translated))
+        if (translated.length > 0 && !root.isUnresolvedKey(schema.description, translated))
             return translated;
         const dk = schema.description_key || "";
-        return root.isUnresolvedKey(dk) ? "" : dk;
+        return root.isUnresolvedKey(dk, dk) ? "" : dk;
     }
     // Bare http(s) URLs in the description become clickable links
     readonly property string descriptionHtml: {


### PR DESCRIPTION

`SettingField` prints whatever lands in `label_key`/`description_key`, and two
different kinds of string land there. A source plugin's Lua `label`/`description`
are copied in verbatim (`control_proto.rs`, `source_setting_to_proto`) and are human
text. A renderer manifest declares a dotted i18n key instead (`label_key =
"settings.video.hwdec"`), and nothing resolves it: `setting_def_to_proto` passes it
through, `renderer_query.cpp` hands it to QML, QML prints it.

So the renderer settings form shows the key where the name belongs. Status page →
`waywallen-video` → gear, on 0.3.5: `settings.video.enable_audio`,
`settings.video.volume`, `settings.video.hwdec`, `settings.video.render_node`,
`settings.video.loop_file`, `settings.video.fps`. The image, wescene and weweb
manifests declare their keys the same way.

The fallback already in the file — snake_case → Title Case of `key` — gives "Enable
Audio", "Volume", "Hwdec", "Render Node", "Loop File", "Fps", which is what should be
on screen until the keys resolve. So a dotted, space-free value is treated as a key
and falls through to that fallback, and an unresolved `description_key` is dropped
rather than printed. Labels from source plugins contain spaces and pass untouched.

I built the UI twice against a running 0.3.5 daemon (Arch, KDE Wayland) and opened
that same form: the key list above without the patch, the name list with it. Nothing
else in the form changed. `qmllint` reports no new diagnostics.

Where those keys should eventually resolve is #210; this only keeps the raw key off
the user's screen in the meantime.

