### PR TITLE
display: listen before display clients reconnect on D-Bus name claim

### DIFF
--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -86,6 +86,9 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
     let dbus_conn = system::dbus::acquire_or_handoff(handoff_ui).await;
     log::info!("DBus name acquired: {}", system::dbus::BUS_NAME);
 
+    let display_sock_path = display::endpoint::default_socket_path();
+    let display_listener = display::endpoint::bind_socket(&display_sock_path).await?;
+
     let mut plugin_roots = plugin::renderer_registry::standard_plugin_roots("plugins");
     for plugin_dir in &cli.plugin_dirs {
         plugin_roots.push(plugin::renderer_registry::PluginRoot::system(
@@ -317,7 +320,6 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
     // transient handshake failures.
     event_process::spawn(state.clone(), cli.restore_last);
 
-    let display_sock_path = display::endpoint::default_socket_path();
     {
         let router = router.clone();
         let sock_path = display_sock_path.clone();
@@ -326,9 +328,15 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
         state
             .tasks
             .spawn_async(tasks::TaskKind::Service, "display/endpoint", async move {
-                display::endpoint::serve_with_shutdown(&sock_path, router, events_tx, shutdown_rx)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("display endpoint exited: {e}"))
+                display::endpoint::serve_bound(
+                    &sock_path,
+                    display_listener,
+                    router,
+                    events_tx,
+                    shutdown_rx,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("display endpoint exited: {e}"))
             });
     }
     if let Some(def) = display_backend {

--- a/src/wallframe/display/endpoint.rs
+++ b/src/wallframe/display/endpoint.rs
@@ -66,15 +66,39 @@ pub async fn serve_with_shutdown(
     sock_path: &Path,
     router: Arc<Router>,
     events_tx: tokio::sync::broadcast::Sender<GlobalEvent>,
-    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
-    let _ = std::fs::remove_file(sock_path);
+    let listener = bind_socket(sock_path).await?;
+    serve_bound(sock_path, listener, router, events_tx, shutdown_rx).await
+}
+
+pub async fn bind_socket(sock_path: &Path) -> Result<tokio::net::UnixListener> {
+    match std::fs::remove_file(sock_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            log::warn!(
+                "failed to remove stale display socket {}: {e}",
+                sock_path.display()
+            );
+        }
+    }
     if let Some(parent) = sock_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     let listener = tokio::net::UnixListener::bind(sock_path)
         .with_context(|| format!("bind display socket at {}", sock_path.display()))?;
     log::info!("display endpoint listening on {}", sock_path.display());
+    Ok(listener)
+}
+
+pub async fn serve_bound(
+    sock_path: &Path,
+    listener: tokio::net::UnixListener,
+    router: Arc<Router>,
+    events_tx: tokio::sync::broadcast::Sender<GlobalEvent>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> Result<()> {
     let mut clients = tokio::task::JoinSet::new();
 
     loop {
@@ -124,6 +148,17 @@ pub async fn serve_with_shutdown(
     while let Some(joined) = clients.join_next().await {
         if let Err(error) = joined {
             log::warn!("display client task join failed during shutdown: {error}");
+        }
+    }
+    drop(listener);
+    match std::fs::remove_file(sock_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            log::warn!(
+                "failed to remove display socket {}: {e}",
+                sock_path.display()
+            );
         }
     }
     Ok(())


### PR DESCRIPTION
# Summary
- Bind display.sock immediately after claiming the D-Bus name, instead of only after GPU/DB initialization, so an already-running display plugin (KDE Plasma) can connect() immediately on restart instead of hitting the ~10s reconnect backoff. This is especially important after resuming from suspend, where the display plugin could sometimes have to wait ~10s before reconnecting.
- Split binding from accepting connections in the display endpoint, and unlink the socket on shutdown so the next start does not encounter a stale socket.
- RefreshDisplays is unchanged (it still re-emits Ready) and remains available as a fallback.