### PR TITLE
ui: improve reset and restore actions

### DIFF
--- a/ui/i18n/waywallen_zh_CN.ts
+++ b/ui/i18n/waywallen_zh_CN.ts
@@ -412,6 +412,14 @@
         <translation>恢复全局默认值</translation>
     </message>
     <message>
+        <source>Revert layout settings?</source>
+        <translation>恢复布局设置？</translation>
+    </message>
+    <message>
+        <source>The settings for this layout will be reverted to the global default. Your custom configuration will be lost.</source>
+        <translation>当前布局将恢复为全局默认设置，自定义配置将会丢失。</translation>
+    </message>
+    <message>
         <source>Fill mode</source>
         <translation>填充模式</translation>
     </message>
@@ -1171,6 +1179,14 @@ Related display: #%1</source>
     <message>
         <source>Reset</source>
         <translation>重置</translation>
+    </message>
+    <message>
+        <source>Reset settings?</source>
+        <translation>重置设置？</translation>
+    </message>
+    <message>
+        <source>All settings will be reset to their defaults. Your custom configuration will be lost.</source>
+        <translation>所有设置将恢复为默认值，个性化配置将会丢失。</translation>
     </message>
     <message>
         <source>Failed to update login startup</source>

--- a/ui/qml/page/DisplaysPage.qml
+++ b/ui/qml/page/DisplaysPage.qml
@@ -1365,7 +1365,7 @@ MD.Page {
                                         const ovr = root.selected.layoutOverride || ({});
                                         return ovr.fillmodeSet === true || ovr.locationSet === true || ovr.alignSet === true || ovr.rotationSet === true;
                                     }
-                                    icon.name: MD.Token.icon.refresh
+                                    icon.name: MD.Token.icon.settings_backup_restore
                                     MD.ToolTip.visible: hovered
                                     MD.ToolTip.text: qsTr("Revert to global default")
                                     onClicked: root.resetLayout()

--- a/ui/qml/page/DisplaysPage.qml
+++ b/ui/qml/page/DisplaysPage.qml
@@ -281,6 +281,23 @@ MD.Page {
         }
     }
 
+    MD.Dialog {
+        id: resetDisplaySettingsDialog
+        parent: T.Overlay.overlay
+        modal: true
+        title: qsTr("Revert layout settings?")
+        standardButtons: T.Dialog.Cancel | T.Dialog.Reset
+        contentItem: MD.Text {
+            text: qsTr("The settings for this layout will be reverted to the global default. Your custom configuration will be lost.")
+            wrapMode: Text.Wrap
+            color: MD.Token.color.on_surface_variant
+        }
+        onReset: {
+            root.resetLayout()
+            resetDisplaySettingsDialog.close()
+        }
+    }
+
     function canvasRows(canvasObject) {
         return canvasEditor.rowsForCanvas(canvasObject);
     }
@@ -1368,7 +1385,7 @@ MD.Page {
                                     icon.name: MD.Token.icon.settings_backup_restore
                                     MD.ToolTip.visible: hovered
                                     MD.ToolTip.text: qsTr("Revert to global default")
-                                    onClicked: root.resetLayout()
+                                    onClicked: resetDisplaySettingsDialog.open()
                                 }
                             }
                         }

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -17,7 +17,7 @@ MD.Page {
 
     actions: [
         MD.Action {
-            icon.name: MD.Token.icon.refresh
+            icon.name: MD.Token.icon.settings_backup_restore
             text: qsTr("Reset")
             enabled: Object.keys(getQ.global).length > 0
             onTriggered: root.resetSettings()

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -20,9 +20,26 @@ MD.Page {
             icon.name: MD.Token.icon.settings_backup_restore
             text: qsTr("Reset")
             enabled: Object.keys(getQ.global).length > 0
-            onTriggered: root.resetSettings()
+            onTriggered: resetSettingsDialog.open()
         }
     ]
+
+    MD.Dialog {
+        id: resetSettingsDialog
+        parent: T.Overlay.overlay
+        modal: true
+        title: qsTr("Reset settings?")
+        standardButtons: T.Dialog.Cancel | T.Dialog.Reset
+        contentItem: MD.Text {
+            text: qsTr("All settings will be reset to their defaults. Your custom configuration will be lost.")
+            wrapMode: Text.Wrap
+            color: MD.Token.color.on_surface_variant
+        }
+        onReset: {
+            root.resetSettings()
+            resetSettingsDialog.close()
+        }
+    }
 
     component FieldLabel: MD.Text {
         typescale: MD.Token.typescale.label_large


### PR DESCRIPTION
Hi! This is my first time contributing to this and similar projects, so please tell me if I did anything incorrectly or if there is anything I should change.

**This PR includes the following changes:**

- Change the reset icon from `MD.Token.icon.refresh` to `MD.Token.icon.settings_backup_restore` to make the action clearer.
- Add confirmation dialogs before actually resetting the settings to avoid accidental presses.

I also added the Chinese translations for the dialogs I added.

**Known Issues:**

- Originally, the program resets the settings whenever the user presses the reset button, which was fine originally. However, after I added a confirmation dialog, the user is asked if they want to reset the settings every time they press it, even when the settings are already at their defaults.
- I don't know Russian, so I haven't added Russian translations for the dialogs. I feel like it would be better to leave them to someone who knows Russian. Please tell me if I should do otherwise.

**Before:**
[Video](https://github.com/user-attachments/assets/1be591b3-2cea-41c5-9215-a08fc18be19a)

**After:**
[Video](https://github.com/user-attachments/assets/7fbfdc57-99ff-4c83-b265-0da50b604abe)
