### PR TITLE
bridge: initialize ancillary and signed decode values

### DIFF
--- a/bridge/src/bridge.c
+++ b/bridge/src/bridge.c
@@ -168,6 +168,7 @@ int ww_bridge_send_frame(int sock, uint16_t opcode, const uint8_t* body, size_t 
     msg.msg_iovlen = iov_count;
 
     if (n_fds > 0) {
+        memset(&cmsg_storage, 0, sizeof(cmsg_storage));
         msg.msg_control      = cmsg_storage.buf;
         msg.msg_controllen   = CMSG_SPACE(sizeof(int) * n_fds);
         struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);

--- a/bridge/src/ipc_v3.c
+++ b/bridge/src/ipc_v3.c
@@ -242,7 +242,7 @@ static int rd_bool(ww_rd_t *r, bool *out) {
     return WW_OK;
 }
 static int rd_i32(ww_rd_t *r, int32_t *out) {
-    uint32_t v; int rc = rd_u32(r, &v); *out = (int32_t)v; return rc;
+    uint32_t v; int rc = rd_u32(r, &v); if (rc) return rc; *out = (int32_t)v; return WW_OK;
 }
 static int rd_u64(ww_rd_t *r, uint64_t *out) {
     int rc = rd_need(r, 8);
@@ -256,7 +256,7 @@ static int rd_u64(ww_rd_t *r, uint64_t *out) {
     return WW_OK;
 }
 static int rd_i64(ww_rd_t *r, int64_t *out) {
-    uint64_t v; int rc = rd_u64(r, &v); *out = (int64_t)v; return rc;
+    uint64_t v; int rc = rd_u64(r, &v); if (rc) return rc; *out = (int64_t)v; return WW_OK;
 }
 static int rd_f32(ww_rd_t *r, float *out) {
     uint32_t bits; int rc = rd_u32(r, &bits); if (rc) return rc;

--- a/tools/wayproto-gen/src/codegen_c.rs
+++ b/tools/wayproto-gen/src/codegen_c.rs
@@ -667,7 +667,7 @@ static int rd_bool(ww_rd_t *r, bool *out) {
     return WW_OK;
 }
 static int rd_i32(ww_rd_t *r, int32_t *out) {
-    uint32_t v; int rc = rd_u32(r, &v); *out = (int32_t)v; return rc;
+    uint32_t v; int rc = rd_u32(r, &v); if (rc) return rc; *out = (int32_t)v; return WW_OK;
 }
 static int rd_u64(ww_rd_t *r, uint64_t *out) {
     int rc = rd_need(r, 8);
@@ -681,7 +681,7 @@ static int rd_u64(ww_rd_t *r, uint64_t *out) {
     return WW_OK;
 }
 static int rd_i64(ww_rd_t *r, int64_t *out) {
-    uint64_t v; int rc = rd_u64(r, &v); *out = (int64_t)v; return rc;
+    uint64_t v; int rc = rd_u64(r, &v); if (rc) return rc; *out = (int64_t)v; return WW_OK;
 }
 static int rd_f32(ww_rd_t *r, float *out) {
     uint32_t bits; int rc = rd_u32(r, &bits); if (rc) return rc;


### PR DESCRIPTION
1. zero the SCM_RIGHTS control buffer before sendmsg so the padding
kernel reads on odd fd counts is deterministic, not stack garbage.

2. static-analyzer nit: guard rd_i32/rd_i64 on the decoder error
path so *out isn't written from an indeterminate value