### PR TITLE
feat(plugin): cap each plugin's Lua VM memory

### DIFF
--- a/src/plugin/source/runtime.rs
+++ b/src/plugin/source/runtime.rs
@@ -150,6 +150,8 @@ impl LuaPluginRuntime {
 
     pub fn with_probe(probe: Arc<dyn MediaProbe>) -> Result<Self> {
         let lua = Lua::new();
+        lua.set_memory_limit(LUA_PLUGIN_MEMORY_LIMIT)
+            .map_err(|error| Error::Internal(anyhow!("set Lua memory limit: {error}")))?;
         let http_cookie_store = Arc::new(mlua_extra::http::SessionCookieStore::default());
         let http_client = reqwest::Client::builder()
             .user_agent(WAYWALLEN_HTTP_USER_AGENT)

--- a/src/plugin/source/tests.rs
+++ b/src/plugin/source/tests.rs
@@ -1886,3 +1886,83 @@ return M
         Some("0.1 0.2 0.3")
     );
 }
+
+#[tokio::test]
+async fn plugin_oom_is_catchable_reusable_and_isolated() {
+    let dir = tempfile::tempdir().unwrap();
+    let heavy_path = dir.path().join("heavy.lua");
+    let light_path = dir.path().join("light.lua");
+    // `heavy` builds a large table only when the query is "overflow"; `light` is trivial.
+    std::fs::write(
+        &heavy_path,
+        r#"
+local M = {}
+function M.info()
+    return { name = "heavy", capabilities = { discover = { search = true } } }
+end
+M.discover = {}
+function M.discover.search(ctx, params)
+    if params.query == "overflow" then
+        local t = {}
+        local chunk = string.rep("x", 1024 * 1024)
+        for i = 1, 512 do t[i] = chunk .. tostring(i) end
+    end
+    return { items = {}, has_more = false }
+end
+return M
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &light_path,
+        r#"
+local M = {}
+function M.info()
+    return { name = "light", capabilities = { discover = { search = true } } }
+end
+M.discover = {}
+function M.discover.search(ctx, params)
+    return { items = {}, has_more = false }
+end
+return M
+"#,
+    )
+    .unwrap();
+
+    let mgr = SourceManager::new().unwrap();
+    mgr.load_plugin(&heavy_path, "org.heavy", "1", ENTRY_VERSION_V3)
+        .unwrap();
+    mgr.load_plugin(&light_path, "org.light", "1", ENTRY_VERSION_V3)
+        .unwrap();
+
+    // Tighten ONLY the heavy VM's cap just above its live usage so the over-allocation
+    // trips it deterministically (keyed off used_memory, not a fixed baseline).
+    {
+        let rt = mgr.test_runtime("heavy");
+        let guard = rt.lock().await;
+        let cap = guard.lua.used_memory() + 8 * 1024 * 1024;
+        guard.lua.set_memory_limit(cap).unwrap();
+    }
+
+    // The overrun surfaces as a typed Err (mlua MemoryError -> Error::DiscoverFailed),
+    // not a panic/abort; the redacted message carries "memory".
+    let err = mgr
+        .call_discover("heavy", "overflow", "", 1, &[])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::DiscoverFailed { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert!(
+        err.to_string().to_lowercase().contains("memory"),
+        "message: {err}"
+    );
+
+    // The SAME plugin's VM is reusable afterwards (on-demand emergency GC reclaims the
+    // failed callback's now-unreachable table).
+    assert!(mgr.call_discover("heavy", "", "", 1, &[]).await.is_ok());
+
+    // The OTHER plugin's VM is provably unaffected.
+    assert!(mgr.call_discover("light", "", "", 1, &[]).await.is_ok());
+}

--- a/src/plugin/source/types.rs
+++ b/src/plugin/source/types.rs
@@ -4,6 +4,10 @@ use super::*;
 pub(super) const WAYWALLEN_HTTP_USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) waywallen";
 pub(super) const LUA_CALLBACK_TIMEOUT: Duration = Duration::from_secs(25);
 pub(super) const LUA_HOOK_INSTRUCTION_INTERVAL: u32 = 10_000;
+/// Per-plugin Lua heap cap. Turns an accidental Lua-side runaway in one plugin into a
+/// catchable `MemoryError` instead of unbounded daemon growth; it does not bound
+/// Rust-side allocations (HTTP/JSON/HTML bodies).
+pub(super) const LUA_PLUGIN_MEMORY_LIMIT: usize = 128 * 1024 * 1024;
 pub(super) const RUNTIME_ACTIVE: u8 = 0;
 pub(super) const RUNTIME_DRAINING: u8 = 1;
 pub(super) const RUNTIME_INACTIVE: u8 = 2;


### PR DESCRIPTION
This is sort of a followup to documentation trust model for 3P plugins. Each source plugin runs in its own Lua VM, and none of them had a memory limit — so a plugin that grows the Lua heap without bound could drag the whole daemon toward OOM and (potentially) take every wallpaper down with it.

This PR adds a 128 MiB per-VM cap, applied in `with_probe` right after the VM is created (so it re-applies on every reload too). When a plugin goes over, mlua raises a catchable `MemoryError` scoped to that one VM: the offending call fails cleanly, the plugin's VM stays usable (verified this), and every other plugin and the control plane keep running.

Scope (for this PR): this only bounds Lua-allocator memory. Rust-side buffers (HTTP/JSON/HTML bodies built by the host helpers) are invisible to it and are a separate concern.