### PR TITLE
feat: add file logging with configurable log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -916,6 +936,22 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4945fa9cdfd7571192cf559c186d45ab36c8034482a2d217a19bdc566f190cc"
+dependencies = [
+ "chrono",
+ "core_affinity",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1824,6 +1860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1881,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3691,6 +3746,7 @@ dependencies = [
  "cc",
  "clap",
  "env_logger",
+ "flexi_logger",
  "futures-util",
  "glob",
  "libc",
@@ -3773,6 +3829,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +3852,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ashpd = { version = "0.9.2", default-features = false, features = ["tokio"] }
 thiserror = "2"
 log = "0.4"
 env_logger = "0.10"
+flexi_logger = { version = "0.31", default-features = false, features = ["async", "colors", "textfilter"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "charset", "stream"] }
 sha2 = "0.10"
 uuid = { version = "1.0", features = ["v4"] }

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,0 +1,40 @@
+# Logging
+
+Waywallen writes daily daemon logs under:
+
+- `$XDG_STATE_HOME/waywallen/logs/` when `XDG_STATE_HOME` is set
+- otherwise `~/.local/state/waywallen/logs/`
+
+When neither `XDG_STATE_HOME` nor `HOME` is set, the daemon logs to stderr only.
+
+Files are named `waywallen_rYYYY-MM-DD.log`, appended across restarts. On rotation, flexi_logger 0.31 `Cleanup::KeepLogFiles(7)` keeps at most the seven newest rotated log files and deletes older ones.
+
+Each log line uses flexi_logger `opt_format` (timestamp + level + file:line). Stderr uses the colored variant of the same format. File I/O is asynchronous and flushed about every 2 seconds, so lines may appear in the log file with a short delay.
+
+## Debug logging setting
+
+In **Settings**, enable **Debug logging** to raise the daemon filter from the default (`info,zbus=warn`) to `debug,zbus=warn`. The change applies immediately to both the log file and stderr.
+
+When `RUST_LOG` is set in the daemon environment, the Settings toggle is disabled and shows *Disabled because RUST_LOG is set.* The saved debug preference is not modified; removing `RUST_LOG` and restarting restores the saved setting.
+
+Use **Log folder → Open** in Settings to open the log directory in the file manager.
+
+## Environment overrides
+
+When `RUST_LOG` is set, it overrides the Debug logging setting for the daemon filter:
+
+```bash
+export RSTD_LOG=debug RUST_LOG=debug,zbus=warn
+./waywallen
+```
+
+- `RUST_LOG` — Rust/`flexi_logger` filter for the daemon
+- `RSTD_LOG` — C++/`rstd` plugin loggers (not controlled by the Debug logging setting)
+
+## Child process stderr
+
+Renderer and display child stderr is forwarded to the daemon log at **debug** level with target `waywallen::child`, prefixed by role (`[renderer]` / `[display]`). Severity is not inferred from message text.
+
+## Changing the default filter in code
+
+There is no build-time flag (Cargo feature / AppImage script) for the default level. Edit `DEFAULT_FILTER` and `DEBUG_FILTER` in `src/logging/policy.rs` and rebuild. `DEFAULT_FILTER` is used at daemon init and whenever Debug logging is off (unless `RUST_LOG` is set). The Debug logging setting uses `filter_for_debug(true)` → `DEBUG_FILTER`.

--- a/README.CN.md
+++ b/README.CN.md
@@ -86,7 +86,8 @@ Waywallen 是一个为 Linux 桌面打造的动态壁纸解决方案。<br>
   NVIDIA 用户应使用 [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver)，通过 VA-API 暴露 NVDEC。  
 
 - 如何获取日志？  
-  首先需要退出正在运行的 Waywallen 守护进程。
+  日志按天写入 `~/.local/state/waywallen/logs/`（或 `$XDG_STATE_HOME/waywallen/logs/`），最多保留 7 个轮转日志文件（`waywallen_rYYYY-MM-DD.log`）。  
+  如需提高详细程度，请先退出正在运行的守护进程，然后：
   ```bash
   export RSTD_LOG=debug RUST_LOG=debug,zbus=warn
   ./waywallen

--- a/README.RU.md
+++ b/README.RU.md
@@ -86,7 +86,8 @@ Waywallen — решение для динамических обоев на р�
   Пользователям NVIDIA следует использовать [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver), чтобы использовать NVDEC через VA-API.
 
 - Как получить логи?  
-  Сначала завершите работающий демон Waywallen.
+  Посуточные логи пишутся в `~/.local/state/waywallen/logs/` (или `$XDG_STATE_HOME/waywallen/logs/`) и хранятся до 7 ротированных файлов логов (`waywallen_rYYYY-MM-DD.log`).  
+  Чтобы повысить подробность, остановите демон и перезапустите:
   ```bash
   export RSTD_LOG=debug RUST_LOG=debug,zbus=warn
   ./waywallen

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ It started life as a Wallpaper Engine plugin for KDE.
   NVIDIA users should use [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver) to expose NVDEC through VA-API.
 
 - How to get logs?  
-  First, stop the running Waywallen daemon.
+  Daily logs are written under `~/.local/state/waywallen/logs/` (or `$XDG_STATE_HOME/waywallen/logs/`), keeping up to 7 rotated log files (`waywallen_rYYYY-MM-DD.log`).  
+  To raise verbosity, stop the running daemon and restart with:
   ```bash
   export RSTD_LOG=debug RUST_LOG=debug,zbus=warn
   ./waywallen

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -1554,6 +1554,10 @@ message GlobalSettings {
   // Hide the tray icon. The daemon applies this live; the window can
   // be reopened by launching waywallen again. `--no-tray` overrides.
   bool hide_tray_icon = 26;
+
+  // Raise the daemon log filter to debug (file + stderr). Honored unless
+  // RUST_LOG is set. Applied live.
+  bool debug_logging_enabled = 27;
 }
 
 enum AutoAction {
@@ -1598,6 +1602,10 @@ message SettingsGetResponse {
   GlobalSettings global = 1;
   // Keyed by runtime component name (renderer name or Lua source name).
   map<string, PluginSettings> plugins = 2;
+  // Absolute path of the daemon log directory (read-only).
+  string log_dir = 3;
+  // True when RUST_LOG is set in the daemon environment (read-only).
+  bool rust_log_active = 4;
 }
 
 // Full replace. The daemon overwrites global and the plugin map with

--- a/src/api/websocket/handlers.rs
+++ b/src/api/websocket/handlers.rs
@@ -1781,6 +1781,10 @@ pub(super) async fn dispatch_inner(
                     .into_iter()
                     .map(|(k, v)| (k, pb::PluginSettings { values: v }))
                     .collect(),
+                log_dir: crate::logging::log_dir()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default(),
+                rust_log_active: crate::logging::rust_log_active(),
             })
         }
 
@@ -1829,6 +1833,7 @@ pub(super) async fn dispatch_inner(
             let prev_queue_mode = previous_settings.global.queue_mode.clone();
             let prev_rotation_secs = previous_settings.global.rotation_secs;
             let prev_hide_tray = previous_settings.global.hide_tray_icon;
+            let prev_debug_logging = previous_settings.global.debug_logging_enabled;
             state.settings.update(|s| {
                 if let Some(g) = r.global.as_ref() {
                     let filters: Vec<_> = g
@@ -1898,10 +1903,15 @@ pub(super) async fn dispatch_inner(
                         }
                     }
                     s.global.hide_tray_icon = g.hide_tray_icon;
+                    s.global.debug_logging_enabled = g.debug_logging_enabled;
                 }
                 s.plugins = new_plugins.clone();
             });
             let current_settings = state.settings.snapshot();
+            let new_debug_logging = current_settings.global.debug_logging_enabled;
+            if new_debug_logging != prev_debug_logging {
+                crate::logging::apply_debug_setting(new_debug_logging);
+            }
             let new_filter = current_settings.global.wallpaper_filter.clone();
             if new_filter != previous_filter {
                 log::debug!(

--- a/src/api/websocket/mapping.rs
+++ b/src/api/websocket/mapping.rs
@@ -726,6 +726,7 @@ pub(super) fn global_to_pb(g: &crate::settings::GlobalSettings) -> pb::GlobalSet
             volume: Some(g.renderer.effective_volume()),
         }),
         hide_tray_icon: g.hide_tray_icon,
+        debug_logging_enabled: g.debug_logging_enabled,
     }
 }
 

--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -135,6 +135,7 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
     renderer_mgr.start_reaper();
     let settings_store =
         settings::SettingsStore::load_or_default(settings::default_config_path()).await;
+    crate::logging::apply_debug_setting(settings_store.global().debug_logging_enabled);
     renderer_mgr.attach_settings(settings_store.clone());
     router.attach_settings(settings_store.clone());
     let registry_snapshot = renderer_mgr.registry_snapshot();
@@ -142,10 +143,19 @@ pub async fn run(cli: DaemonConfig) -> anyhow::Result<()> {
 
     let system_info = Arc::new(system::SystemInfo::load());
     renderer_mgr.attach_system_info(system_info.clone());
-    log::info!("system: discovered {} GPU(s)", system_info.gpus().len());
+    let gpu_count = system_info.gpus().len();
+    if gpu_count == 0 {
+        log::warn!(
+            target: "waywallen::gpu",
+            "no GPU render nodes detected; Vulkan/VA-API hardware paths will be unavailable"
+        );
+    } else {
+        log::info!(target: "waywallen::gpu", "system: discovered {gpu_count} GPU(s)");
+    }
     for g in system_info.gpus() {
-        log::debug!(
-            "  gpu: render={:?} primary={:?} drm={}:{} pci={:?} name={:?} {} ({:#06x}:{:#06x})",
+        log::info!(
+            target: "waywallen::gpu",
+            "gpu: render={:?} primary={:?} drm={}:{} pci={:?} name={:?} {} ({:#06x}:{:#06x})",
             g.render_node,
             g.primary_node,
             g.render_major,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod daemon;
 pub mod error;
 mod event_process;
 pub mod events;
+pub mod logging;
 pub mod model;
 pub mod playback;
 pub mod plugin;

--- a/src/logging/child_stdio.rs
+++ b/src/logging/child_stdio.rs
@@ -1,0 +1,61 @@
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::ChildStderr;
+
+pub const TARGET_RENDERER: &str = "renderer";
+
+pub const TARGET_DISPLAY: &str = "display";
+
+const CHILD_LOG_TARGET: &str = "waywallen::child";
+
+/// Format a non-empty child stderr line for the daemon log.
+pub(crate) fn format_child_stderr_line(role: &str, line: &str) -> Option<String> {
+    if line.trim().is_empty() {
+        None
+    } else {
+        Some(format!("[{role}] {line}"))
+    }
+}
+
+/// Pipe child stderr into the daemon logger without blocking the child.
+pub fn forward_stderr(stderr: ChildStderr, role: &'static str) {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if let Some(message) = format_child_stderr_line(role, &line) {
+                        log::debug!(target: CHILD_LOG_TARGET, "{message}");
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    log::warn!(
+                        target: CHILD_LOG_TARGET,
+                        "Failed to read child stderr ({role}): {error}"
+                    );
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_child_stderr_line_prefixes_role() {
+        assert_eq!(
+            format_child_stderr_line("renderer", "failed to initialize"),
+            Some("[renderer] failed to initialize".to_string())
+        );
+    }
+
+    #[test]
+    fn format_child_stderr_line_ignores_empty_and_whitespace() {
+        assert_eq!(format_child_stderr_line("renderer", ""), None);
+        assert_eq!(format_child_stderr_line("display", "   "), None);
+        assert_eq!(format_child_stderr_line("display", "\n"), None);
+    }
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,250 @@
+//! Code-configured async file logging for the waywallen daemon.
+//!
+//! Tune behavior via [`LoggingPolicy::DEFAULT`]. Runtime filter still honors
+//! `RUST_LOG` when set. Child-process stderr is forwarded through
+//! [`forward_stderr`].
+
+mod child_stdio;
+mod paths;
+mod policy;
+
+pub use child_stdio::{forward_stderr, TARGET_DISPLAY, TARGET_RENDERER};
+pub use paths::log_dir;
+pub use policy::{filter_for_debug, LoggingPolicy, DEBUG_FILTER, DEFAULT, DEFAULT_FILTER};
+
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use flexi_logger::{
+    colored_opt_format, opt_format, Age, Cleanup, Criterion, Duplicate, FileSpec, Logger,
+    LoggerHandle, Naming, WriteMode,
+};
+
+/// Global logger handle, initialized once per process.
+///
+/// [`LoggingGuard`] shuts down the writer on drop, but this `OnceLock` is never
+/// reset — re-initializing logging in the same process is not supported.
+static LOGGER_HANDLE: OnceLock<LoggerHandle> = OnceLock::new();
+
+/// Keeps the flexi_logger async writer alive until process exit.
+///
+/// On drop, shuts down the underlying writer. The global [`LOGGER_HANDLE`] entry
+/// is not cleared; a second init in the same process is not supported.
+pub struct LoggingGuard {
+    handle: Option<LoggerHandle>,
+}
+
+impl Drop for LoggingGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.shutdown();
+        }
+    }
+}
+
+/// Whether the daemon environment sets `RUST_LOG`, overriding the debug setting.
+pub fn rust_log_active() -> bool {
+    std::env::var_os("RUST_LOG").is_some()
+}
+
+/// Initialize logging under the default XDG state log directory.
+pub fn init(policy: LoggingPolicy) -> LoggingGuard {
+    match log_dir() {
+        Some(dir) => init_in(policy, &dir),
+        None => {
+            eprintln!("waywallen: XDG_STATE_HOME and HOME unset; using stderr-only logging");
+            init_stderr_only(policy)
+        }
+    }
+}
+
+/// Initialize logging under an explicit directory (tests / overrides).
+pub fn init_in(policy: LoggingPolicy, dir: &Path) -> LoggingGuard {
+    if let Err(error) = std::fs::create_dir_all(dir) {
+        eprintln!(
+            "waywallen: cannot create log directory {}: {error}; falling back to stderr-only",
+            dir.display()
+        );
+        return init_stderr_only(policy);
+    }
+
+    match try_init_file(policy, dir) {
+        Ok(handle) => {
+            log::info!(
+                "logging: writing to {} (keep at most {} rotated log file(s))",
+                dir.display(),
+                policy.retention_days
+            );
+            LoggingGuard {
+                handle: Some(register_handle(handle)),
+            }
+        }
+        Err(error) => {
+            eprintln!("waywallen: file logging unavailable ({error}); falling back to stderr-only");
+            init_stderr_only(policy)
+        }
+    }
+}
+
+pub fn apply_debug_setting(enabled: bool) {
+    if rust_log_active() {
+        log::info!("debug_logging_enabled ignored because RUST_LOG is set");
+        return;
+    }
+    let Some(handle) = LOGGER_HANDLE.get() else {
+        return;
+    };
+    let filter = filter_for_debug(enabled);
+    match handle.parse_new_spec(filter) {
+        Ok(()) => log::info!("log filter set to {filter}"),
+        Err(error) => log::warn!("failed to apply log filter {filter}: {error}"),
+    }
+}
+
+fn register_handle(handle: LoggerHandle) -> LoggerHandle {
+    let _ = LOGGER_HANDLE.set(handle.clone());
+    handle
+}
+
+fn try_init_file(
+    policy: LoggingPolicy,
+    dir: &Path,
+) -> Result<LoggerHandle, flexi_logger::FlexiLoggerError> {
+    let mut logger = Logger::try_with_env_or_str(policy.default_filter)?
+        .log_to_file(
+            FileSpec::default()
+                .directory(dir)
+                .basename(policy.file_prefix)
+                .suppress_timestamp(),
+        )
+        .format_for_files(opt_format)
+        .append()
+        .rotate(
+            Criterion::Age(Age::Day),
+            Naming::TimestampsCustomFormat {
+                current_infix: None,
+                format: "r%Y-%m-%d",
+            },
+            Cleanup::KeepLogFiles(usize::from(policy.retention_days)),
+        )
+        .write_mode(WriteMode::AsyncWith {
+            pool_capa: policy.async_channel_size.max(32),
+            message_capa: 1024,
+            flush_interval: Duration::from_secs(2),
+        });
+
+    if policy.also_stderr {
+        logger = logger
+            .duplicate_to_stderr(Duplicate::All)
+            .format_for_stderr(colored_opt_format);
+    }
+
+    logger.start()
+}
+
+fn init_stderr_only(policy: LoggingPolicy) -> LoggingGuard {
+    match Logger::try_with_env_or_str(policy.default_filter).and_then(|logger| {
+        logger
+            .log_to_stderr()
+            .format_for_stderr(colored_opt_format)
+            .start()
+    }) {
+        Ok(handle) => LoggingGuard {
+            handle: Some(register_handle(handle)),
+        },
+        Err(error) => {
+            eprintln!("waywallen: stderr logging init failed: {error}");
+            LoggingGuard { handle: None }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static INIT_LOCK: Mutex<()> = Mutex::new(());
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        INIT_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn init_writes_daily_log_file() {
+        let _guard = test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let logging = init_in(LoggingPolicy::DEFAULT, dir.path());
+        log::info!(target: "waywallen::logging_test", "smoke-test-line");
+        drop(logging);
+
+        let mut found = false;
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if name.starts_with("waywallen_r") && name.ends_with(".log") {
+                let contents = fs::read_to_string(&path).unwrap();
+                if contents.contains("smoke-test-line") {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(found, "expected smoke-test-line in a waywallen_r*.log file");
+
+        // opt_format prefixes each line with [YYYY-MM-DD HH:MM:SS...]
+        let mut timestamped = false;
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !(name.starts_with("waywallen_r") && name.ends_with(".log")) {
+                continue;
+            }
+            let contents = fs::read_to_string(&path).unwrap();
+            if contents
+                .lines()
+                .any(|line| line.starts_with('[') && line.contains("smoke-test-line"))
+            {
+                timestamped = true;
+                break;
+            }
+        }
+        assert!(
+            timestamped,
+            "expected opt_format timestamp prefix on smoke-test-line"
+        );
+    }
+
+    #[test]
+    fn rust_log_active_reflects_environment() {
+        let _guard = test_lock();
+        std::env::remove_var("RUST_LOG");
+        assert!(!rust_log_active());
+
+        std::env::set_var("RUST_LOG", "info");
+        assert!(rust_log_active());
+
+        std::env::remove_var("RUST_LOG");
+        assert!(!rust_log_active());
+    }
+
+    #[test]
+    fn rust_log_is_temporary_override_of_persisted_debug_preference() {
+        let _guard = test_lock();
+
+        // Persisted user preference stays enabled regardless of RUST_LOG.
+        let debug_logging_enabled = true;
+
+        std::env::set_var("RUST_LOG", "info");
+        assert!(rust_log_active());
+        assert_eq!(filter_for_debug(debug_logging_enabled), DEBUG_FILTER);
+
+        std::env::remove_var("RUST_LOG");
+        assert!(!rust_log_active());
+        assert_eq!(filter_for_debug(debug_logging_enabled), DEBUG_FILTER);
+    }
+}

--- a/src/logging/paths.rs
+++ b/src/logging/paths.rs
@@ -1,0 +1,60 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// `$XDG_STATE_HOME/waywallen/logs`, else `~/.local/state/waywallen/logs`.
+///
+/// Returns `None` when neither `XDG_STATE_HOME` nor `HOME` is set.
+pub fn log_dir() -> Option<PathBuf> {
+    log_dir_from(|key| std::env::var_os(key))
+}
+
+/// Testable variant of [`log_dir`].
+pub fn log_dir_from(get: impl Fn(&str) -> Option<OsString>) -> Option<PathBuf> {
+    if let Some(xdg) = get("XDG_STATE_HOME") {
+        return Some(PathBuf::from(xdg).join("waywallen").join("logs"));
+    }
+    if let Some(home) = get("HOME") {
+        return Some(
+            PathBuf::from(home)
+                .join(".local")
+                .join("state")
+                .join("waywallen")
+                .join("logs"),
+        );
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn prefers_xdg_state_home() {
+        let dir = log_dir_from(|key| match key {
+            "XDG_STATE_HOME" => Some(OsString::from("/tmp/state")),
+            "HOME" => Some(OsString::from("/home/user")),
+            _ => None,
+        });
+        assert_eq!(dir, Some(PathBuf::from("/tmp/state/waywallen/logs")));
+    }
+
+    #[test]
+    fn falls_back_to_home_local_state() {
+        let dir = log_dir_from(|key| match key {
+            "HOME" => Some(OsString::from("/home/user")),
+            _ => None,
+        });
+        assert_eq!(
+            dir,
+            Some(PathBuf::from("/home/user/.local/state/waywallen/logs"))
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_home_or_xdg() {
+        let dir = log_dir_from(|_| None);
+        assert_eq!(dir, None);
+    }
+}

--- a/src/logging/policy.rs
+++ b/src/logging/policy.rs
@@ -1,0 +1,43 @@
+/// Tunable logging behavior. Prefer editing [`LoggingPolicy::DEFAULT`].
+#[derive(Debug, Clone, Copy)]
+pub struct LoggingPolicy {
+    pub retention_days: u8,
+    pub file_prefix: &'static str,
+    pub default_filter: &'static str,
+    pub also_stderr: bool,
+    pub async_channel_size: usize,
+}
+
+pub const DEFAULT_FILTER: &str = "info,zbus=warn";
+pub const DEBUG_FILTER: &str = "debug,zbus=warn";
+
+pub fn filter_for_debug(enabled: bool) -> &'static str {
+    if enabled {
+        DEBUG_FILTER
+    } else {
+        DEFAULT_FILTER
+    }
+}
+
+impl LoggingPolicy {
+    pub const DEFAULT: Self = Self {
+        retention_days: 7,
+        file_prefix: "waywallen",
+        default_filter: DEFAULT_FILTER,
+        also_stderr: true,
+        async_channel_size: 1024,
+    };
+}
+
+pub const DEFAULT: LoggingPolicy = LoggingPolicy::DEFAULT;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_for_debug_selects_expected_strings() {
+        assert_eq!(filter_for_debug(false), DEFAULT_FILTER);
+        assert_eq!(filter_for_debug(true), DEBUG_FILTER);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    let _logging = waywallen::logging::init(waywallen::logging::LoggingPolicy::DEFAULT);
 
     let config = waywallen::daemon::DaemonConfig::from_env();
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -16,6 +16,7 @@ mod paths;
 mod schema;
 mod store;
 
+pub use crate::logging::log_dir;
 pub use paths::{
     data_dir, default_config_path, default_db_path, plugin_state_dir, remote_content_dir,
     sanitize_path_segment,

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -315,6 +315,8 @@ pub struct GlobalSettings {
     /// Hide the StatusNotifierItem tray icon. Applied live; the
     /// `--no-tray` CLI flag forces the tray off regardless.
     pub hide_tray_icon: bool,
+
+    pub debug_logging_enabled: bool,
 }
 
 impl Default for GlobalSettings {
@@ -342,6 +344,7 @@ impl Default for GlobalSettings {
             pointer_forwarding_enabled: true,
             autostart_enabled: false,
             hide_tray_icon: false,
+            debug_logging_enabled: false,
         }
     }
 }

--- a/src/wallframe/display/spawner.rs
+++ b/src/wallframe/display/spawner.rs
@@ -261,11 +261,13 @@ pub fn log_outcome(outcome: &PickOutcome, caps: &DeCaps) {
         PickOutcome::None => {
             if caps.is_kde() {
                 log::warn!(
-                    "no KDE display backend registered; install waywallen-kde or configure a manifest"
+                    target: "waywallen::display",
+                    "no display backend detected for KDE; install waywallen-kde or configure a manifest"
                 );
             } else {
                 log::warn!(
-                    "no display backend matched xdg_desktop={:?}; daemon will run in pure external-consumer mode",
+                    target: "waywallen::display",
+                    "no display backend / monitors path matched xdg_desktop={:?}; daemon will run in pure external-consumer mode",
                     caps.xdg_desktop
                 );
             }
@@ -381,14 +383,11 @@ pub async fn run_backend(
         cmd.env("WAYWALLEN_SOCKET", &socket);
         cmd.kill_on_drop(true)
             .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
+            .stderr(Stdio::piped());
 
-        // Linux-only safety net: `kill_on_drop(true)` covers clean exits.
-        // PDEATHSIG also handles abrupt parent death.
         #[cfg(target_os = "linux")]
         unsafe {
             cmd.pre_exec(|| {
-                // prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0)
                 let rc = libc::prctl(
                     libc::PR_SET_PDEATHSIG,
                     libc::SIGTERM as libc::c_ulong,
@@ -407,7 +406,8 @@ pub async fn run_backend(
             Ok(c) => c,
             Err(e) => {
                 log::error!(
-                    "spawn '{}' failed: {e}; backend will not run",
+                    "display backend spawn failed: backend={} spawn={}: {e}; backend will not run",
+                    def.name,
                     def.bin.display()
                 );
                 // Not recoverable: wrong path, permissions, etc. Don't
@@ -415,6 +415,9 @@ pub async fn run_backend(
                 return Err(e.into());
             }
         };
+        if let Some(stderr) = child.stderr.take() {
+            crate::logging::forward_stderr(stderr, crate::logging::TARGET_DISPLAY);
+        }
         let pid = child.id();
         log::info!("display backend '{}' pid={:?}", def.name, pid);
 

--- a/src/wallframe/renderer_manager/mod.rs
+++ b/src/wallframe/renderer_manager/mod.rs
@@ -858,11 +858,14 @@ impl RendererManager {
         }
         cmd.kill_on_drop(true)
             .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
+            .stderr(Stdio::piped());
 
         let mut child = cmd
             .spawn()
             .with_context(|| format!("spawn {}", renderer_def.bin.display()))?;
+        if let Some(stderr) = child.stderr.take() {
+            crate::logging::forward_stderr(stderr, crate::logging::TARGET_RENDERER);
+        }
         let child_pid = child.id();
         let process_group = child_pid.and_then(|pid| i32::try_from(pid).ok());
         let process_group_registration = self.register_process_group(process_group);

--- a/tests/logging_retention.rs
+++ b/tests/logging_retention.rs
@@ -1,0 +1,72 @@
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+
+use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming, WriteMode};
+use waywallen::logging::{LoggingPolicy, DEFAULT_FILTER};
+
+fn count_rotated_logs(dir: &Path) -> usize {
+    fs::read_dir(dir)
+        .unwrap()
+        .flatten()
+        .filter(|entry| {
+            entry
+                .path()
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("waywallen_r") && name.ends_with(".log"))
+        })
+        .count()
+}
+
+#[test]
+fn keep_log_files_retains_at_most_n_newest_on_rotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let keep = 3_u8;
+    let policy = LoggingPolicy {
+        retention_days: keep,
+        also_stderr: false,
+        ..LoggingPolicy::DEFAULT
+    };
+
+    let mut logger = Logger::try_with_str(DEFAULT_FILTER)
+        .unwrap()
+        .log_to_file(
+            FileSpec::default()
+                .directory(dir.path())
+                .basename(policy.file_prefix)
+                .suppress_timestamp(),
+        )
+        .append()
+        .rotate(
+            Criterion::Age(Age::Second),
+            Naming::TimestampsCustomFormat {
+                current_infix: None,
+                format: "r%Y-%m-%d",
+            },
+            Cleanup::KeepLogFiles(usize::from(keep)),
+        )
+        .write_mode(WriteMode::AsyncWith {
+            pool_capa: 32,
+            message_capa: 1024,
+            flush_interval: Duration::from_secs(2),
+        });
+
+    if policy.also_stderr {
+        logger = logger.duplicate_to_stderr(Duplicate::All);
+    }
+
+    let handle = logger.start().expect("logger init");
+
+    for i in 0..5 {
+        log::info!(target: "waywallen::logging_test", "rotation-trigger-{i}");
+        std::thread::sleep(Duration::from_secs(2));
+    }
+    handle.shutdown();
+
+    let remaining = count_rotated_logs(dir.path());
+    assert!(
+        remaining <= usize::from(keep),
+        "flexi_logger KeepLogFiles({keep}) should leave at most {keep} rotated logs, found {remaining}"
+    );
+}

--- a/ui/qml/page/SettingsPage.qml
+++ b/ui/qml/page/SettingsPage.qml
@@ -185,6 +185,21 @@ MD.Page {
         m_flush.restart();
     }
 
+    function logFolderUrl() {
+        let path = String(getQ.logDir || "");
+        if (path.length === 0)
+            return "";
+        if (path.indexOf("file://") === 0)
+            return path;
+        return "file://" + path.split("/").map(encodeURIComponent).join("/");
+    }
+
+    function openLogFolder() {
+        const url = root.logFolderUrl();
+        if (url.length > 0)
+            MD.Util.openFolderExternally(url);
+    }
+
     property int autoReplayRevision: 0
     property int pauseEffectRevision: 0
 
@@ -250,7 +265,8 @@ MD.Page {
             "renderer.volume": 100,
             pluginUpdateNotifications: true,
             duplicateRenderers: false,
-            hideTrayIcon: false
+            hideTrayIcon: false,
+            debugLoggingEnabled: false
         };
     }
 
@@ -295,7 +311,8 @@ MD.Page {
             rendererVolume: root._rendererVolume(g),
             pluginUpdateNotifications: Boolean(g.pluginUpdateNotifications ?? true),
             duplicateRenderers: Boolean(g.duplicateRenderers ?? false),
-            hideTrayIcon: Boolean(g.hideTrayIcon ?? false)
+            hideTrayIcon: Boolean(g.hideTrayIcon ?? false),
+            debugLoggingEnabled: Boolean(g.debugLoggingEnabled ?? false)
         });
     }
 
@@ -715,6 +732,68 @@ MD.Page {
                         target: m_hide_tray_icon
                         property: "checked"
                         value: Boolean(root._currentGlobal()?.hideTrayIcon ?? false)
+                    }
+                }
+            }
+
+            SettingItem {
+                first: false
+                last: false
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        FieldLabel { text: qsTr("Debug logging") }
+
+                        MD.Text {
+                            text: getQ.rustLogActive
+                                ? qsTr("Disabled because RUST_LOG is set.")
+                                : qsTr("Include debug-level messages in the log file (debug,zbus=warn). Takes effect immediately.")
+                            typescale: MD.Token.typescale.body_small
+                            color: MD.Token.color.on_surface_variant
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    MD.Switch {
+                        id: m_debug_logging
+                        enabled: !getQ.rustLogActive
+                        onToggled: root._mut(g => {
+                            g.debugLoggingEnabled = checked;
+                        })
+                    }
+                    Binding {
+                        target: m_debug_logging
+                        property: "checked"
+                        value: Boolean(root._currentGlobal()?.debugLoggingEnabled ?? false)
+                    }
+                }
+            }
+
+            SettingItem {
+                first: false
+                last: false
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    FieldLabel {
+                        Layout.fillWidth: true
+                        text: qsTr("Log folder")
+                    }
+
+                    MD.Button {
+                        text: qsTr("Open")
+                        mdState.type: MD.Enum.BtText
+                        enabled: String(getQ.logDir || "").length > 0
+                        onClicked: root.openLogFolder()
                     }
                 }
             }

--- a/ui/src/query/settings_query.cpp
+++ b/ui/src/query/settings_query.cpp
@@ -120,7 +120,8 @@ auto global_to_map(const proto::GlobalSettings& g) -> QVariantMap {
         ! has_renderer || ! g.renderer().hasEnableAudio() || g.renderer().enableAudio();
     m[u"renderer.volume"_s] =
         has_renderer && g.renderer().hasVolume() ? g.renderer().volume() : 100;
-    m[u"hideTrayIcon"_s] = g.hideTrayIcon();
+    m[u"hideTrayIcon"_s]        = g.hideTrayIcon();
+    m[u"debugLoggingEnabled"_s] = g.debugLoggingEnabled();
     QStringList wallpaper_skip_types;
     for (const auto& t : g.wallpaperSkipTypes()) {
         wallpaper_skip_types.append(t);
@@ -216,6 +217,9 @@ auto map_to_global(const QVariantMap& m) -> proto::GlobalSettings {
     if (m.contains(u"hideTrayIcon"_s)) {
         g.setHideTrayIcon(m.value(u"hideTrayIcon"_s).toBool());
     }
+    if (m.contains(u"debugLoggingEnabled"_s)) {
+        g.setDebugLoggingEnabled(m.value(u"debugLoggingEnabled"_s).toBool());
+    }
     if (m.contains(u"wallpaperSkipTypes"_s)) {
         QStringList skip;
         for (const auto& v : m.value(u"wallpaperSkipTypes"_s).toList()) {
@@ -265,6 +269,8 @@ SettingsGetQuery::SettingsGetQuery(QObject* parent): Query(parent) {}
 
 auto SettingsGetQuery::global() const -> const QVariantMap& { return m_global; }
 auto SettingsGetQuery::plugins() const -> const QVariantMap& { return m_plugins; }
+auto SettingsGetQuery::logDir() const -> const QString& { return m_log_dir; }
+auto SettingsGetQuery::rustLogActive() const -> bool { return m_rust_log_active; }
 
 void SettingsGetQuery::reload() {
     setStatus(Status::Querying);
@@ -280,11 +286,15 @@ void SettingsGetQuery::reload() {
         if (! self) co_return;
 
         self->inspect_set(result, [self](const proto::Response& rsp) {
-            const auto& get_rsp = rsp.settingsGet();
-            self->m_global      = global_to_map(get_rsp.global());
-            self->m_plugins     = plugins_to_map(get_rsp.plugins());
+            const auto& get_rsp     = rsp.settingsGet();
+            self->m_global          = global_to_map(get_rsp.global());
+            self->m_plugins         = plugins_to_map(get_rsp.plugins());
+            self->m_log_dir         = get_rsp.logDir();
+            self->m_rust_log_active = get_rsp.rustLogActive();
             Q_EMIT self->globalChanged();
             Q_EMIT self->pluginsChanged();
+            Q_EMIT self->logDirChanged();
+            Q_EMIT self->rustLogActiveChanged();
         });
         co_return;
     });

--- a/ui/src/query/settings_query.cppm
+++ b/ui/src/query/settings_query.cppm
@@ -23,21 +23,29 @@ export class SettingsGetQuery : public Query,
 
     Q_PROPERTY(QVariantMap global READ global NOTIFY globalChanged FINAL)
     Q_PROPERTY(QVariantMap plugins READ plugins NOTIFY pluginsChanged FINAL)
+    Q_PROPERTY(QString logDir READ logDir NOTIFY logDirChanged FINAL)
+    Q_PROPERTY(bool rustLogActive READ rustLogActive NOTIFY rustLogActiveChanged FINAL)
 
 public:
     SettingsGetQuery(QObject* parent = nullptr);
 
     auto global() const -> const QVariantMap&;
     auto plugins() const -> const QVariantMap&;
+    auto logDir() const -> const QString&;
+    auto rustLogActive() const -> bool;
 
     void reload() override;
 
     Q_SIGNAL void globalChanged();
     Q_SIGNAL void pluginsChanged();
+    Q_SIGNAL void logDirChanged();
+    Q_SIGNAL void rustLogActiveChanged();
 
 private:
     QVariantMap m_global;
     QVariantMap m_plugins;
+    QString     m_log_dir;
+    bool        m_rust_log_active = false;
 };
 
 /// Apply a full-replace settings write. Caller must populate both


### PR DESCRIPTION
# Improve logging and simplify log collection

## Summary

Improve Waywallen's logging and make collecting diagnostic logs significantly easier for users.

Waywallen previously required users to stop the running daemon, set environment variables, and launch the binary manually to obtain useful logs:

```bash
export RSTD_LOG=debug
export RUST_LOG=debug,zbus=warn
./waywallen
```

This is difficult to explain to non-technical users and is especially inconvenient when Waywallen is installed through AppImage or Flatpak.

This change makes persistent file logging the default, so logs are available without requiring the user to manually start the daemon with special environment variables.

## Changes

* Enable persistent file logging by default.
* Store logs in the user's XDG state directory, with `$HOME/.local/state/waywallen/logs` as fallback.
* Continue supporting `RUST_LOG` as a temporary override for debugging.
* Expose when `RUST_LOG` is active and disable the Debug Logging setting while it overrides the configuration.
* Make the default and debug filters explicit:

  * `info,zbus=warn`
  * `debug,zbus=warn`
* Forward renderer/display stderr to `waywallen::child` at `debug` level
* Fall back to stderr-only logging only when no persistent user state directory is available.
* Update logging documentation.

## User impact

Users no longer need to stop Waywallen, set environment variables, or manually launch the daemon just to provide logs.

For normal installations, logs are generated automatically and can be collected from the configured log directory. `RUST_LOG` remains available for developers and advanced troubleshooting when more specific logging configuration is required.
