### PR TITLE
ui: show why a plugin update check failed

### DIFF
--- a/ui/qml/page/PluginManagePage.qml
+++ b/ui/qml/page/PluginManagePage.qml
@@ -64,6 +64,35 @@ MD.Page {
         return "";
     }
 
+    // The daemon already reports why a check failed; surface it instead of
+    // leaving the tag unexplained. The message is backend text and is shown as
+    // sent, only folded so a long manifest URL cannot stretch the tooltip past
+    // the window.
+    function updateTagTooltip(info) {
+        const state = updateState(info);
+        if (state !== pluginUpdateStateFailed && state !== pluginUpdateStateUnsupported)
+            return "";
+        return foldMessage(info && info.error ? String(info.error) : "", 64);
+    }
+
+    function foldMessage(message, limit) {
+        const lines = [];
+        for (let word of message.split(" ")) {
+            while (word.length > limit) {
+                lines.push(word.substring(0, limit));
+                word = word.substring(limit);
+            }
+            if (word.length === 0)
+                continue;
+            const last = lines.length - 1;
+            if (last >= 0 && lines[last].length + 1 + word.length <= limit)
+                lines[last] += " " + word;
+            else
+                lines.push(word);
+        }
+        return lines.join("\n");
+    }
+
     function updateTagBgColor(info) {
         const state = updateState(info);
         if (state === pluginUpdateStateAvailable)
@@ -499,10 +528,21 @@ MD.Page {
                         z: 2
 
                         W.Tag {
+                            id: pluginUpdateTag
+                            readonly property string reason: root.updateTagTooltip(pluginItem.modelData.updateInfo)
+
                             visible: root.updateTagVisible(pluginItem.modelData.updateInfo)
                             text: root.updateTagText(pluginItem.modelData.updateInfo)
                             bgColor: root.updateTagBgColor(pluginItem.modelData.updateInfo)
                             fgColor: root.updateTagFgColor(pluginItem.modelData.updateInfo)
+
+                            HoverHandler {
+                                id: pluginUpdateTagHover
+                            }
+
+                            MD.ToolTip.visible: pluginUpdateTagHover.hovered && pluginUpdateTag.reason.length > 0
+                            MD.ToolTip.delay: 300
+                            MD.ToolTip.text: pluginUpdateTag.reason
                         }
                         W.Tag {
                             text: "v" + (pluginItem.modelData.version || "0.0.0")


### PR DESCRIPTION
A failed update check shows only a red "Check failed" tag, so a dropped
connection looks the same as a broken manifest. The reason is already on the
wire in PluginUpdateInfo.error and the UI keeps it in the model, it is just
never shown. This puts that message in a tooltip on the tag, the way GpuTag and
RuntimeConditionTag already explain themselves. Backend text is shown as sent,
only folded into short lines so a long manifest URL cannot stretch the tooltip
past the window; no new translatable strings. Checked on a local build against
a daemon whose plugins point at unreachable manifest URLs.
