### PR TITLE
Fix daemon file logging panic on startup

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -7,8 +7,7 @@ Waywallen writes daily daemon logs under:
 
 When neither `XDG_STATE_HOME` nor `HOME` is set, the daemon logs to stderr only.
 
-Files are named `waywallen_rYYYY-MM-DD.log`, appended across restarts. On rotation, flexi_logger 0.31 `Cleanup::KeepLogFiles(7)` keeps at most the seven newest rotated log files and deletes older ones.
-
+The active daemon log is `waywallen_rCURRENT.log`, appended across restarts. On daily rotation it becomes `waywallen_rYYYY-MM-DD_00-00-00.log` (the `_00-00-00` suffix is a flexi_logger compatibility shim, not a real timestamp). flexi_logger 0.31 `Cleanup::KeepLogFiles(7)` keeps at most the seven newest rotated log files and deletes older ones.
 Each log line uses flexi_logger `opt_format` (timestamp + level + file:line). Stderr uses the colored variant of the same format. File I/O is asynchronous and flushed about every 2 seconds, so lines may appear in the log file with a short delay.
 
 ## Debug logging setting

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Waywallen is built by [Lito](https://github.com/litocpp/lito) (Please star it)
   NVIDIA users should use [nvidia-vaapi-driver](https://github.com/elFarto/nvidia-vaapi-driver) to expose NVDEC through VA-API.
 
 - How to get logs?  
-  Daily logs are written under `~/.local/state/waywallen/logs/` (or `$XDG_STATE_HOME/waywallen/logs/`), keeping up to 7 rotated log files (`waywallen_rYYYY-MM-DD.log`).  
+  Daily daemon logs are written under `~/.local/state/waywallen/logs/` (or `$XDG_STATE_HOME/waywallen/logs/`): active file `waywallen_rCURRENT.log`, rotated archives `waywallen_rYYYY-MM-DD_00-00-00.log` (up to 7 kept). 
   To raise verbosity, stop the running daemon and restart with:
   ```bash
   export RSTD_LOG=debug RUST_LOG=debug,zbus=warn

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -123,8 +123,8 @@ fn try_init_file(
         .rotate(
             Criterion::Age(Age::Day),
             Naming::TimestampsCustomFormat {
-                current_infix: None,
-                format: "r%Y-%m-%d",
+                current_infix: Some("rCURRENT"),
+                format: "r%Y-%m-%d_00-00-00",
             },
             Cleanup::KeepLogFiles(usize::from(policy.retention_days)),
         )
@@ -182,41 +182,43 @@ mod tests {
         log::info!(target: "waywallen::logging_test", "smoke-test-line");
         drop(logging);
 
-        let mut found = false;
-        for entry in fs::read_dir(dir.path()).unwrap() {
-            let path = entry.unwrap().path();
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if name.starts_with("waywallen_r") && name.ends_with(".log") {
-                let contents = fs::read_to_string(&path).unwrap();
-                if contents.contains("smoke-test-line") {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        assert!(found, "expected smoke-test-line in a waywallen_r*.log file");
-
-        // opt_format prefixes each line with [YYYY-MM-DD HH:MM:SS...]
-        let mut timestamped = false;
-        for entry in fs::read_dir(dir.path()).unwrap() {
-            let path = entry.unwrap().path();
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if !(name.starts_with("waywallen_r") && name.ends_with(".log")) {
-                continue;
-            }
-            let contents = fs::read_to_string(&path).unwrap();
-            if contents
-                .lines()
-                .any(|line| line.starts_with('[') && line.contains("smoke-test-line"))
-            {
-                timestamped = true;
-                break;
-            }
-        }
+        let current = dir.path().join("waywallen_rCURRENT.log");
+        assert!(current.is_file(), "expected {}", current.display());
+        let contents = fs::read_to_string(&current).unwrap();
         assert!(
-            timestamped,
+            contents.contains("smoke-test-line"),
+            "expected smoke-test-line in {}",
+            current.display()
+        );
+        assert!(
+            contents
+                .lines()
+                .any(|line| line.starts_with('[') && line.contains("smoke-test-line")),
             "expected opt_format timestamp prefix on smoke-test-line"
         );
+    }
+
+    #[test]
+    fn init_with_legacy_short_rotated_log_does_not_panic() {
+        let _guard = test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let legacy = dir.path().join("waywallen_r2026-08-26.log");
+        let display = dir.path().join("waywallen_display_r2026-08-26.log");
+        fs::write(&legacy, "daemon\n").unwrap();
+        fs::write(&display, "display\n").unwrap();
+
+        let logging = init_in(LoggingPolicy::DEFAULT, dir.path());
+        log::info!(target: "waywallen::logging_test", "post-init-line");
+        drop(logging);
+
+        assert!(
+            legacy.is_file(),
+            "legacy daemon log should be left in place"
+        );
+        assert_eq!(fs::read_to_string(&legacy).unwrap(), "daemon\n");
+        assert!(display.is_file(), "display log must remain untouched");
+        let current = fs::read_to_string(dir.path().join("waywallen_rCURRENT.log")).unwrap();
+        assert!(current.contains("post-init-line"));
     }
 
     #[test]

--- a/tests/logging_retention.rs
+++ b/tests/logging_retention.rs
@@ -14,7 +14,11 @@ fn count_rotated_logs(dir: &Path) -> usize {
                 .path()
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("waywallen_r") && name.ends_with(".log"))
+                .is_some_and(|name| {
+                    name.starts_with("waywallen_r")
+                        && name.ends_with(".log")
+                        && name.contains("_00-00-00")
+                })
         })
         .count()
 }
@@ -41,8 +45,8 @@ fn keep_log_files_retains_at_most_n_newest_on_rotation() {
         .rotate(
             Criterion::Age(Age::Second),
             Naming::TimestampsCustomFormat {
-                current_infix: None,
-                format: "r%Y-%m-%d",
+                current_infix: Some("rCURRENT"),
+                format: "r%Y-%m-%d_00-00-00",
             },
             Cleanup::KeepLogFiles(usize::from(keep)),
         )


### PR DESCRIPTION
# Fix daemon logging panic on restart

Fixes a regression introduced in #231 where the daemon would panic on startup when previous log files were present.

## Problem

PR #231 added persistent file logging with daily rotation using `flexi_logger 0.31`. However, the configuration used a short timestamp format (`r%Y-%m-%d`, 11 bytes) with `current_infix: None`, which causes `flexi_logger` to scan existing rotated files during initialization.

`flexi_logger 0.31` hardcodes a 20-byte infix length assumption in [`timestamps.rs:25`](https://docs.rs/flexi_logger/0.31.10/src/flexi_logger/writers/file_log_writer/state/timestamps.rs.html#25). When it encounters a rotated file with the shorter 11-byte format, it attempts to read beyond the string bounds, triggering a panic:

```
thread 'flexi_logger-file-writer' panicked at timestamps.rs:25:63:
range end index 80 out of range for slice of length 75
```

This killed the file writer thread, causing all subsequent log writes to fail silently with `[flexi_logger][ERRCODE::Write]`. Logs continued to stderr but were never written to disk.

## Solution

Switch to the recommended `Naming::TimestampsCustomFormat` pattern with:
- **`current_infix: Some("rCURRENT")`** — writes to a fixed active file (`waywallen_rCURRENT.log`), avoiding the directory scan that triggered the panic
- **`format: "r%Y-%m-%d_00-00-00"`** — produces 20-byte rotation infixes compatible with flexi_logger's hardcoded assumption

The `_00-00-00` suffix is a compatibility shim (not a real timestamp) to satisfy flexi_logger's length requirement while maintaining daily rotation semantics.

## Changes

- Active daemon log: `waywallen_rCURRENT.log` (appended across restarts)
- Rotated archives: `waywallen_rYYYY-MM-DD_00-00-00.log` (one per day, up to 7 kept)
- Legacy short-format files (`waywallen_rYYYY-MM-DD.log`) remain in the directory but are ignored
- Updated `LOGGING.md` and `README.md` to reflect new filenames

## Testing

Added regression test `init_with_legacy_short_rotated_log_does_not_panic` that verifies:
- Daemon initializes successfully when legacy short-format logs exist
- No panic occurs during startup
- New logs are written to `rCURRENT.log`
- Legacy daemon and display-backend logs are left untouched

Updated existing tests to use the new format.