### PR TITLE
tray: translate the menu labels

### DIFF
--- a/src/system/tray/dbusmenu.rs
+++ b/src/system/tray/dbusmenu.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use zbus::{interface, zvariant};
 use zvariant::{OwnedValue, StructureBuilder, Value};
 
+use super::i18n::tr;
 use crate::application;
 use crate::DaemonContext;
 
@@ -334,12 +335,12 @@ pub async fn notify_menu_changed(app: &Arc<DaemonContext>) {
 
 fn build_root(menu: &MenuState) -> ItemStruct {
     let children: Vec<OwnedValue> = vec![
-        item_to_value(make_leaf(ID_OPEN_UI, "Open UI", None)),
-        item_to_value(make_leaf(ID_NEXT, "Next", None)),
-        item_to_value(make_leaf(ID_PREV, "Previous", None)),
+        item_to_value(make_leaf(ID_OPEN_UI, tr("Open UI"), None)),
+        item_to_value(make_leaf(ID_NEXT, tr("Next"), None)),
+        item_to_value(make_leaf(ID_PREV, tr("Previous"), None)),
         item_to_value(make_leaf(ID_SEP1, "", Some("separator"))),
-        item_to_value(make_checkmark(ID_SHUFFLE, "Shuffle", menu.is_shuffle)),
-        item_to_value(make_submenu_parent(ID_ROTATE, "Rotate")),
+        item_to_value(make_checkmark(ID_SHUFFLE, tr("Shuffle"), menu.is_shuffle)),
+        item_to_value(make_submenu_parent(ID_ROTATE, tr("Rotate"))),
         item_to_value(make_leaf(ID_SEP_PL, "", Some("separator"))),
         item_to_value(make_leaf(
             ID_PAUSE,
@@ -352,9 +353,9 @@ fn build_root(menu: &MenuState) -> ItemStruct {
             None,
         )),
         item_to_value(make_leaf(ID_SEP2, "", Some("separator"))),
-        item_to_value(make_leaf(ID_RESCAN, "Rescan wallpapers", None)),
+        item_to_value(make_leaf(ID_RESCAN, tr("Rescan wallpapers"), None)),
         item_to_value(make_leaf(ID_SEP3, "", Some("separator"))),
-        item_to_value(make_leaf(ID_QUIT, "Quit", None)),
+        item_to_value(make_leaf(ID_QUIT, tr("Quit"), None)),
     ];
     (ID_ROOT, root_props(), children)
 }
@@ -362,12 +363,14 @@ fn build_root(menu: &MenuState) -> ItemStruct {
 fn build_rotate_submenu(menu: &MenuState) -> ItemStruct {
     let children: Vec<OwnedValue> = rotate_options()
         .iter()
-        .map(|(id, label, secs)| item_to_value(make_radio(*id, label, menu.rotation_secs == *secs)))
+        .map(|(id, label, secs)| {
+            item_to_value(make_radio(*id, tr(label), menu.rotation_secs == *secs))
+        })
         .collect();
     let mut props = HashMap::new();
     props.insert(
         "label".into(),
-        OwnedValue::try_from(Value::from("Rotate")).unwrap(),
+        OwnedValue::try_from(Value::from(tr("Rotate"))).unwrap(),
     );
     props.insert(
         "children-display".into(),
@@ -443,17 +446,17 @@ fn make_radio(id: i32, label: &str, on: bool) -> ItemStruct {
 
 fn pause_action_label(paused: bool) -> &'static str {
     if paused {
-        "Resume"
+        tr("Resume")
     } else {
-        "Pause"
+        tr("Pause")
     }
 }
 
 fn mute_action_label(muted: bool) -> &'static str {
     if muted {
-        "Unmute"
+        tr("Unmute")
     } else {
-        "Mute"
+        tr("Mute")
     }
 }
 
@@ -478,23 +481,23 @@ fn make_submenu_parent(id: i32, label: &str) -> ItemStruct {
 fn props_for(id: i32, menu: &MenuState) -> Option<HashMap<String, OwnedValue>> {
     match id {
         ID_ROOT => Some(root_props()),
-        ID_OPEN_UI => Some(make_leaf(id, "Open UI", None).1),
-        ID_NEXT => Some(make_leaf(id, "Next", None).1),
-        ID_PREV => Some(make_leaf(id, "Previous", None).1),
+        ID_OPEN_UI => Some(make_leaf(id, tr("Open UI"), None).1),
+        ID_NEXT => Some(make_leaf(id, tr("Next"), None).1),
+        ID_PREV => Some(make_leaf(id, tr("Previous"), None).1),
         ID_SEP1 | ID_SEP2 | ID_SEP3 | ID_SEP_PL => Some(make_leaf(id, "", Some("separator")).1),
-        ID_SHUFFLE => Some(make_checkmark(id, "Shuffle", menu.is_shuffle).1),
-        ID_ROTATE => Some(make_submenu_parent(id, "Rotate").1),
+        ID_SHUFFLE => Some(make_checkmark(id, tr("Shuffle"), menu.is_shuffle).1),
+        ID_ROTATE => Some(make_submenu_parent(id, tr("Rotate")).1),
         ID_ROT_OFF | ID_ROT_30S | ID_ROT_1M | ID_ROT_5M | ID_ROT_15M | ID_ROT_1H => {
             let (_, label, secs) = rotate_options()
                 .iter()
                 .copied()
                 .find(|(rid, _, _)| *rid == id)?;
-            Some(make_radio(id, label, menu.rotation_secs == secs).1)
+            Some(make_radio(id, tr(label), menu.rotation_secs == secs).1)
         }
         ID_PAUSE => Some(make_leaf(id, pause_action_label(menu.manual_paused), None).1),
         ID_MUTE => Some(make_leaf(id, mute_action_label(menu.manual_muted), None).1),
-        ID_RESCAN => Some(make_leaf(id, "Rescan wallpapers", None).1),
-        ID_QUIT => Some(make_leaf(id, "Quit", None).1),
+        ID_RESCAN => Some(make_leaf(id, tr("Rescan wallpapers"), None).1),
+        ID_QUIT => Some(make_leaf(id, tr("Quit"), None).1),
         _ => None,
     }
 }

--- a/src/system/tray/i18n.rs
+++ b/src/system/tray/i18n.rs
@@ -1,0 +1,121 @@
+//! Translations for the tray menu.
+//!
+//! The tray menu is not drawn by the UI process: the daemon publishes its
+//! labels over `com.canonical.dbusmenu` and the desktop shell renders them
+//! verbatim. The Qt catalogs installed in `waywallen-ui` therefore never
+//! apply to it, and the labels have to be resolved here instead.
+//!
+//! Lookups run against a compile-time table picked from the process locale,
+//! so a missing language or a missing entry simply yields the English source
+//! string.
+
+use std::sync::OnceLock;
+
+/// One language's messages as `(msgid, msgstr)` pairs, sorted by `msgid`.
+type Catalog = &'static [(&'static str, &'static str)];
+
+const RU: Catalog = &[
+    ("1 hour", "1 час"),
+    ("1 minute", "1 минута"),
+    ("15 minutes", "15 минут"),
+    ("30 seconds", "30 секунд"),
+    ("5 minutes", "5 минут"),
+    ("Linux wallpaper daemon", "Демон обоев для Linux"),
+    ("Mute", "Заглушить"),
+    ("Next", "Следующие обои"),
+    ("Off", "Выкл."),
+    ("Open UI", "Открыть интерфейс"),
+    ("Pause", "Пауза"),
+    ("Previous", "Предыдущие обои"),
+    ("Quit", "Выход"),
+    ("Rescan wallpapers", "Пересканировать обои"),
+    ("Resume", "Возобновить"),
+    ("Rotate", "Смена обоев"),
+    ("Shuffle", "Вперемешку"),
+    ("Unmute", "Включить звук"),
+];
+
+fn catalog_for(language: &str) -> Option<Catalog> {
+    match language {
+        "ru" => Some(RU),
+        _ => None,
+    }
+}
+
+/// Primary language subtag of the active locale, lowercased: `ru_RU.UTF-8`
+/// and `ru` both yield `ru`. `C` and `POSIX` mean "no translation".
+fn locale_language() -> Option<String> {
+    for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
+        let value = match std::env::var(key) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if value.is_empty() {
+            continue;
+        }
+        if value == "C" || value == "POSIX" {
+            return None;
+        }
+        let tag = value
+            .split(['.', '@'])
+            .next()
+            .unwrap_or_default()
+            .split(['_', '-'])
+            .next()
+            .unwrap_or_default();
+        if !tag.is_empty() {
+            return Some(tag.to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+fn active_catalog() -> Option<Catalog> {
+    static ACTIVE: OnceLock<Option<Catalog>> = OnceLock::new();
+    *ACTIVE.get_or_init(|| locale_language().as_deref().and_then(catalog_for))
+}
+
+/// Translate a tray label, falling back to the English source string.
+pub fn tr(msgid: &'static str) -> &'static str {
+    let Some(catalog) = active_catalog() else {
+        return msgid;
+    };
+    match catalog.binary_search_by_key(&msgid, |(id, _)| *id) {
+        Ok(index) => catalog[index].1,
+        Err(_) => msgid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogs_are_sorted_and_complete() {
+        for catalog in [RU] {
+            assert!(
+                catalog.windows(2).all(|w| w[0].0 < w[1].0),
+                "catalog entries must be sorted by msgid for binary_search"
+            );
+            assert!(catalog.iter().all(|(_, text)| !text.is_empty()));
+        }
+    }
+
+    #[test]
+    fn lookup_falls_back_to_the_source_string() {
+        assert_eq!(
+            RU.binary_search_by_key(&"Rescan wallpapers", |(id, _)| *id)
+                .map(|i| RU[i].1),
+            Ok("Пересканировать обои")
+        );
+        assert!(RU
+            .binary_search_by_key(&"not a tray label", |(id, _)| *id)
+            .is_err());
+    }
+
+    #[test]
+    fn catalog_is_selected_by_primary_subtag() {
+        assert!(catalog_for("ru").is_some());
+        assert!(catalog_for("en").is_none());
+    }
+}

--- a/src/system/tray/mod.rs
+++ b/src/system/tray/mod.rs
@@ -1,4 +1,5 @@
 pub mod dbusmenu;
+mod i18n;
 mod sni;
 
 use std::sync::Arc;

--- a/src/system/tray/sni.rs
+++ b/src/system/tray/sni.rs
@@ -96,7 +96,7 @@ impl StatusNotifierItem {
             String::new(),
             Vec::new(),
             "waywallen".to_string(),
-            "Linux wallpaper daemon".to_string(),
+            super::i18n::tr("Linux wallpaper daemon").to_string(),
         )
     }
 


### PR DESCRIPTION
The tray menu is published by the daemon over com.canonical.dbusmenu and the shell renders
the labels verbatim, so the Qt catalogs installed by waywallen-ui never reach it: the menu
stays English while the rest of the interface is already translated.

This resolves the labels in the daemon instead, against a compile-time table picked from
LC_ALL/LC_MESSAGES/LANG, and adds a Russian catalog. An unknown language or an unknown
msgid falls back to the English source string, so nothing changes where there is no
catalog. Adding a language is one const table plus one match arm.

Covered: the menu entries, the Rotate submenu presets, the Pause/Resume and Mute/Unmute
labels, and the SNI tooltip.

Verified against a running daemon, not only in tests — private D-Bus session and private
XDG_RUNTIME_DIR, reading GetLayout(0, -1, []) off /MenuBar:

- LANG=ru_RU.UTF-8: Открыть интерфейс, Следующие обои, Предыдущие обои, Вперемешку,
  Смена обоев, Пауза, Заглушить, Пересканировать обои, Выход; submenu Выкл., 30 секунд,
  1 минута, 5 минут, 15 минут, 1 час; tooltip "Демон обоев для Linux".
- LANG=en_US.UTF-8 and LC_ALL=C: the English strings as before, unchanged.

cargo test --release --lib system::tray passes (3 tests).

Open question: the UI keeps its language preference in QSettings, so the daemon can only
follow the process locale today. If the tray is meant to follow the UI's own language
selector, that preference has to reach the daemon first — say the word if you want it
wired that way instead.
