### PR TITLE
i18n(ru): plain wording instead of developer jargon

### DIFF
--- a/ui/i18n/waywallen_ru.ts
+++ b/ui/i18n/waywallen_ru.ts
@@ -26,7 +26,7 @@
     <message>
         <location filename="../qml/page/AboutPage.qml" line="108"/>
         <source>Issues</source>
-        <translation>Баг-трекер</translation>
+        <translation>Сообщить о проблеме</translation>
     </message>
     <message>
         <location filename="../qml/page/AboutPage.qml" line="115"/>
@@ -712,12 +712,12 @@
     <message>
         <location filename="../qml/component/LayerShellDisplaysHelp.qml" line="40"/>
         <source>%1 uses the &lt;b&gt;waywallen-layer-shell&lt;/b&gt; display backend. The daemon is running inside Flatpak%2, where layer-shell Wayland protocols are not available. Start and keep &lt;b&gt;waywallen-layer-shell&lt;/b&gt; running outside Flatpak.</source>
-        <translation>%1 использует бэкенд вывода &lt;b&gt;waywallen-layer-shell&lt;/b&gt;. Демон работает внутри Flatpak%2, где протоколы layer-shell для Wayland недоступны. Запустите &lt;b&gt;waywallen-layer-shell&lt;/b&gt; вне Flatpak и не завершайте его.</translation>
+        <translation>%1 выводит обои через &lt;b&gt;waywallen-layer-shell&lt;/b&gt;. Демон работает внутри Flatpak%2, где протоколы layer-shell для Wayland недоступны. Запустите &lt;b&gt;waywallen-layer-shell&lt;/b&gt; вне Flatpak и не завершайте его.</translation>
     </message>
     <message>
         <location filename="../qml/component/LayerShellDisplaysHelp.qml" line="41"/>
         <source>%1 uses the &lt;b&gt;waywallen-layer-shell&lt;/b&gt; display backend, but the daemon could not find its binary. Install it from GitHub:</source>
-        <translation>%1 использует бэкенд вывода &lt;b&gt;waywallen-layer-shell&lt;/b&gt;, но демон не нашёл его исполняемый файл. Установите его с GitHub:</translation>
+        <translation>%1 выводит обои через &lt;b&gt;waywallen-layer-shell&lt;/b&gt;, но демон не нашёл его исполняемый файл. Установите его с GitHub:</translation>
     </message>
     <message>
         <location filename="../qml/component/LayerShellDisplaysHelp.qml" line="51"/>
@@ -1789,12 +1789,12 @@ Related display: #%1</source>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="618"/>
         <source>Single UI instance</source>
-        <translation>Один экземпляр интерфейса</translation>
+        <translation>Только одно окно</translation>
     </message>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="621"/>
         <source>When enabled, launching Waywallen again focuses the existing window.</source>
-        <translation>При повторном запуске Waywallen фокусируется уже открытое окно.</translation>
+        <translation>Повторный запуск Waywallen просто вернёт на экран уже открытое окно.</translation>
     </message>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="652"/>
@@ -1824,7 +1824,7 @@ Related display: #%1</source>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="751"/>
         <source>Debug logging</source>
-        <translation>Отладочное логирование</translation>
+        <translation>Подробный журнал</translation>
     </message>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="755"/>
@@ -1854,7 +1854,7 @@ Related display: #%1</source>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="838"/>
         <source>Mouse forwarding</source>
-        <translation>Передача событий мыши</translation>
+        <translation>Передавать мышь обоям</translation>
     </message>
     <message>
         <location filename="../qml/page/SettingsPage.qml" line="865"/>
@@ -2637,7 +2637,7 @@ Unsaved frame state may be lost.</source>
     <message>
         <location filename="../qml/page/WallpaperInfoPage.qml" line="216"/>
         <source>Overrides</source>
-        <translation>Переопределения</translation>
+        <translation>Изменённые свойства</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Eight strings in the Russian catalog were written for a developer, not for the person using
the app. The rest of the catalog already sets the tone, so these stand out.

"Debug logging" was "Отладочное логирование" — "логирование" is jargon, and the catalog
already settled on "журнал": "Daemon log" is "Журнал демона", "The log is empty." is
"Журнал пуст.", and the description of this very setting says "в файл журнала". Now
"Подробный журнал".

The rest, same idea:

- Issues: "Баг-трекер" -> "Сообщить о проблеме" (slang, and it is what the button does)
- Overrides: "Переопределения" -> "Изменённые свойства" (next to it we already say
  "Своё расположение" and "Пользовательские свойства")
- Mouse forwarding: "Передача событий мыши" -> "Передавать мышь обоям" ("события" is
  developer speak; the daemon forwards motion/buttons/scroll to the renderer)
- Single UI instance: "Один экземпляр интерфейса" -> "Только одно окно", and its
  description no longer says "фокусируется" — the catalog otherwise translates
  "Focused window" as "Активное окно"
- display backend (x2): "использует бэкенд вывода" -> "выводит обои через"

Technology names stay in Latin as before: Wayland, Flatpak, GitHub, WW_LOG,
waywallen-layer-shell. No sources touched, no messages added or removed —
lrelease generates 535 translations, all finished, no warnings.